### PR TITLE
Introduce muted extension provider to suppress errors

### DIFF
--- a/packages/uix-host/src/extensions-provider/mute.ts
+++ b/packages/uix-host/src/extensions-provider/mute.ts
@@ -10,6 +10,21 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-export * from "./extension-registry.js";
-export * from "./composition.js";
-export * from "./mute.js";
+import {ExtensionsProvider} from "../host.js";
+
+/**
+ * Mute any errors produced by provider.
+ * This function would execute given provider and return its results as is, if any error occurs this provider will log it
+ * any return an empty array of extensions.
+ * @public
+ */
+export function mutedProvider(provider: ExtensionsProvider): ExtensionsProvider {
+    return async () => {
+      try {
+        return await provider()
+      } catch (error) {
+        console.error(`Extension provider has failed: ${error.message}`, {error})
+        return {};
+      }
+    }
+}


### PR DESCRIPTION
Introduce muted extension provider to suppress errors while fetching list of extensions.

## Description

Mute provider allows to gracefully handle errors in case extension provider fails to fetch extension list. It's meant to be used as wrapper to other extension providers like so:

```
<Extensible extensionProvider={combineExtensionFromProviders(muteProvider(provider1), provider2)} ...
```

## Related Issue

- https://jira.corp.adobe.com/browse/DEVX-2717

## Motivation and Context

At the moment we mostly use two providers: extension registry and static provider which gets extensions from `ext` parameter in URL. Sometimes due to configuration or network issues extension registry provider fails and it prevents all extensions from initialization, even static ones.

The idea is to provide an optional "wrapper" to extension registry extension provider which would handle errors gracefully.

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
