### PR TITLE
Improve handling of concurrent load and unload calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "npm run -s build:development",
     "build:development": "node scripts/bundler.mjs development",
     "build:production": "node scripts/bundler.mjs production",
-    "clean": "del {dist,*.tsbuildinfo,docs/temp,.parcel-cache,node_modules/.cache} {packages,examples}/*/{dist,*.tsbuildinfo,node_modules/.cache,.parcel-cache} packages/*/src/**/*.{d.ts,d.ts.map,js,js.map} && npm run -s any -- -s clean",
+    "clean": "del {dist,*.tsbuildinfo,docs/temp,.parcel-cache,node_modules/.cache} {packages,examples}/*/{dist,*.tsbuildinfo,node_modules/.cache,.parcel-cache,node_modules/.vite} packages/*/src/**/*.{d.ts,d.ts.map,js,js.map} && npm run -s any -- -s clean",
     "declarations:build": "tsc --build",
     "declarations:watch": "tsc --build tsconfig.json --watch",
     "demo": "npm run build:production -- --silent && npm run any example:build && node scripts/multi-server.mjs production",

--- a/packages/uix-host-react/src/components/Extensible.tsx
+++ b/packages/uix-host-react/src/components/Extensible.tsx
@@ -43,6 +43,17 @@ export interface ExtensibleProps extends Omit<HostConfig, "hostName"> {
   sharedContext?: SharedContextValues;
 }
 
+function areExtensionsDifferent(
+  set1: InstalledExtensions,
+  set2: InstalledExtensions
+) {
+  const ids1 = Object.keys(set1).sort();
+  const ids2 = Object.keys(set2).sort();
+  return (
+    ids1.length !== ids2.length || ids1.some((id, index) => id !== ids2[index])
+  );
+}
+
 /**
  * Declares an extensible area in an app, and provides host and extension
  * objects to all descendents. The {@link useExtensions} hook can only be called
@@ -73,8 +84,8 @@ export function Extensible({
   const [extensions, setExtensions] = useState({});
   useEffect(() => {
     extensionsProvider()
-      .then((loadedExtensions: InstalledExtensions) => {
-          setExtensions(loadedExtensions);
+      .then((loaded: InstalledExtensions) => {
+          setExtensions((prev) => areExtensionsDifferent(prev, loaded) ? loaded : prev);
       })
       .catch((e: Error | unknown) => {
         console.error("Fetching list of extensions failed!", e);

--- a/packages/uix-host-react/src/components/Extensible.tsx
+++ b/packages/uix-host-react/src/components/Extensible.tsx
@@ -79,7 +79,7 @@ export function Extensible({
   debug,
   sharedContext,
 }: PropsWithChildren<ExtensibleProps>) {
-  const hostName = useMemo(() => appName || window.location.host || "mainframe", [appName]);
+  const hostName = appName || window.location.host || "mainframe";
 
   const [extensions, setExtensions] = useState({});
   useEffect(() => {


### PR DESCRIPTION
Current implementation does not always correctly handles concurrent load and unload method calls on the host. This pull request addresses these issues by providing "concurrency safer" implementation.

## Related Issue

- [DEVX-2598](https://jira.corp.adobe.com/browse/DEVX-2598)

## Motivation and Context

We have observed a situation in production where host load and unload procedures are executed concurrently leading to unpredictable behaviour. 

For example, current implementation of `unload` iterates over guests and unloads each one of them (deletes iframe node) then it deletes container node for iframes. The implementation of `load` starts by creating container (if not exists) and then adds new guest iframews one by one. When these two methods are executed concurrently it makes `load` start adding new set of iframes to a node which is deleted by `unload` milliseconds later, the causes all extensions to disappear. 

Similar issue happens to map of extensions managed by host, `this.guests.clear` is executed by unload after load has started adding entries to the map.

In order to address these concurrency issues I have resorted to making host object non-reusable, meaning a new host is created each time we want to reload extensions, this isolates configuration of each load/unload calls within their own host object. Ie. unload is always triggered on previous version of host and load is always triggered on a new version. 

More specifically:
1. I have moved host creation and extension loading into a single effect, when effect is executed new host is created, extensions are loaded and unload is scheduled as destructor of the effect.
2. We still need to pass host in the context so I have introduce a new state to `Extensible` component which simply tracks latest version of host object and passes it to the context
3. I have modified effect which sets extensions  to correctly handle its dependencies

This implementation has a few minor draft backs:
1. Initial render uses `undefined` value for host, although it's quickly fixed by execution of `setHost` effect


## Types of changes

- Bug fix (non-breaking change which fixes an issue)
