### PR TITLE
add github actions to publish nightly

### DIFF
--- a/.github/workflows/npm-prerelease-nightly.yml
+++ b/.github/workflows/npm-prerelease-nightly.yml
@@ -1,0 +1,30 @@
+name: Publish to NPM
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 23 * * *'  # runs every night at 11pm
+
+jobs:
+  nightly:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up git user
+        uses: fregante/setup-git-user@v1
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Install project dependencies
+        run: npm ci
+      - name: Run test suite
+        run: npm run test
+      - name: Publish to NPM
+        run: |
+          node scripts/release.mjs $( \
+            npm pkg get version | xargs npx semver -i \
+          )-nightly.$(date +%Y%m%d) --tag=nightly --no-git
+        env:
+          NPM_TOKEN: ${{ secrets.ADOBE_BOT_NPM_TOKEN }}

--- a/.github/workflows/npm-publish-manual.yml
+++ b/.github/workflows/npm-publish-manual.yml
@@ -1,4 +1,4 @@
-name: on-push-publish-to-npm
+name: npm-publish-manual
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

New GitHub action publishes main branch nightly to NPM as the next patch version plus `-nightly.YYYYMMDD`. The release is tagged with `nightly`, so a consumer can always install `@adobe/uix-guest@nightly`.

<!--- Describe your changes in detail -->

## Related Issue

[SITES-10794](https://jira.corp.adobe.com/browse/SITES-10794)

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Nightly releases make it possible for consumers to test unreleased features without checking out the repository itself.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

By running the actions on the PR branch.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
