### PR TITLE
remove csp requirement

### DIFF
--- a/packages/uix-host/src/dom-utils/iframe-normalizers.test.ts
+++ b/packages/uix-host/src/dom-utils/iframe-normalizers.test.ts
@@ -19,7 +19,6 @@ describe("normalizeIframe", () => {
     normalizeIframe(frame);
     expect(frame).toMatchInlineSnapshot(`
       <iframe
-        csp="frame-ancestors 'self'"
         data-uix-guest="true"
         referrerpolicy="strict-origin"
         role="presentation"

--- a/packages/uix-host/src/dom-utils/iframe-normalizers.ts
+++ b/packages/uix-host/src/dom-utils/iframe-normalizers.ts
@@ -27,17 +27,27 @@ type SandboxPermission =
   | "scripts"
   | "storage-access-by-user-activation"
   | "top-navigation-by-user-activation";
+
+/**
+ * Character strings allowed in "sandbox=" attribute.
+ * @internal
+ */
 export type SandboxToken = `allow-${SandboxPermission}`;
 
 /**
- * Limit provided set of "sandbox" attributes to a list of legal ones.
+ * Merge lists of attrs together
  * @internal
  */
 export const makeSandboxAttrs = (...sandboxes: AttrTokens<SandboxToken>[]) =>
   mergeAttrValues<SandboxToken>(...sandboxes);
 
+/**
+ * Limit provided set of "sandbox" attributes to a list of legal ones.
+ * @internal
+ */
 export const requiredIframeProps = {
-  csp: "frame-ancestors 'self'",
+  // must not require this until app builder supports CSP
+  // csp: "frame-ancestors 'self'",
   "data-uix-guest": "true",
   role: "presentation",
   referrerPolicy: "strict-origin" as HTMLAttributeReferrerPolicy,
@@ -45,6 +55,10 @@ export const requiredIframeProps = {
 
 const requiredIframeAttrEntries = Object.entries(requiredIframeProps);
 
+/**
+ * Set and/or verify the required properties for use with uix-sdk on an iframe.
+ * @internal
+ */
 export const normalizeIframe = (iframe: HTMLIFrameElement) => {
   for (const [attr, value] of requiredIframeAttrEntries) {
     iframe.setAttribute(attr, value);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Remove the `csp` attribute added to iframes since #19 because it prevents loading of app builder apps which _do not_ have CSP headers, and app builder doesn't currently support CSP headers.

<!--- Describe your changes in detail -->

## Related Issue

[SITES-10778](https://jira.corp.adobe.com/browse/SITES-10778)

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Iframe `csp` attribute completely blocks an iframe which doesn't sent equivalent CSP headers, which is impossible for app builder to do right now.
See [SITES-10778](https://jira.corp.adobe.com/browse/SITES-10778) description.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
