### PR TITLE
feat: custom timeouts in useExtensions consumers

### DIFF
--- a/examples/guest-parcel-plain-zalgo/src/index.js
+++ b/examples/guest-parcel-plain-zalgo/src/index.js
@@ -41,23 +41,28 @@ document.querySelector("#app").innerHTML = `
    <ul>${exampleResults.join("")}</ul>
  `;
 
-register({
-  id: "Zalgo",
-  debug: process.env.NODE_ENV !== "production",
-  methods: {
-    interestingNumbers: {
-      commentOn(n) {
-        // should we say anything?
-        if (Math.random() > 0.7) {
-          return getComments(n);
-        } else {
-          return [];
-        }
-      },
-    },
-  },
-}).then((instance) => {
-  instance.logger.log('he arrive');
-},(e) => {
-  console.error(e);
-});
+ setTimeout(() => {
+   register({
+     id: "Zalgo",
+     debug: process.env.NODE_ENV !== "production",
+     methods: {
+       interestingNumbers: {
+         commentOn(n) {
+           // should we say anything?
+           if (Math.random() > 0.7) {
+             return getComments(n);
+           } else {
+             return [];
+           }
+         },
+       },
+     },
+   }).then(
+     (instance) => {
+       instance.logger.log("he arrive");
+     },
+     (e) => {
+       console.error(e);
+     }
+   );
+ }, 4000);

--- a/packages/uix-core/src/types.ts
+++ b/packages/uix-core/src/types.ts
@@ -171,12 +171,19 @@ export interface UIFrameRect {
 }
 
 /**
+ * @internal
+ */
+export interface GuestConnectionOptions {
+  timeout?: number;
+}
+
+/**
  * Guest UIs
  * @internal
  */
-export interface UIHostMethods {
+export type UIHostMethods = RemoteHostApis<{
   onIframeResize(dimensions: UIFrameRect): void;
-}
+}>;
 
 /**
  * @internal

--- a/packages/uix-host-react/src/components/GuestUIFrame.tsx
+++ b/packages/uix-host-react/src/components/GuestUIFrame.tsx
@@ -10,7 +10,12 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { CrossRealmObject, UIFrameRect, VirtualApi } from "@adobe/uix-core";
+import {
+  CrossRealmObject,
+  GuestConnectionOptions,
+  UIFrameRect,
+  VirtualApi,
+} from "@adobe/uix-core";
 import React, { useEffect, useRef } from "react";
 import type { IframeHTMLAttributes } from "react";
 import { useHost } from "../hooks/useHost.js";
@@ -29,6 +34,7 @@ type FrameProps = Omit<ReactIframeProps, "sandbox">;
 
 /** @public */
 export interface GuestUIProps extends FrameProps {
+  connectOptions: GuestConnectionOptions;
   guestId: string;
   /**
    * Receives the Penpal context when the frame is mounted.
@@ -78,6 +84,7 @@ const defaultSandbox = "allow-scripts allow-forms allow-same-origin";
 export const GuestUIFrame = ({
   guestId,
   src = "",
+  connectOptions,
   onConnect,
   onDisconnect,
   onConnectionError,
@@ -103,7 +110,7 @@ export const GuestUIFrame = ({
       if (methods) {
         guest.provide(methods);
       }
-      const connecting = guest.attachUI(connectionFrame);
+      const connecting = guest.attachUI(connectionFrame, connectOptions);
       connecting
         .then((c) => {
           connection = c;

--- a/packages/uix-host/src/port.ts
+++ b/packages/uix-host/src/port.ts
@@ -21,6 +21,7 @@ import type {
   Unsubscriber,
   VirtualApi,
   UIHostMethods,
+  GuestConnectionOptions,
 } from "@adobe/uix-core";
 import {
   Emitter,
@@ -95,11 +96,7 @@ interface GuestProxyWrapper {
 }
 
 /** @public */
-export type PortOptions = {
-  /**
-   * Time in milliseconds to wait for the guest to connect before throwing.
-   */
-  timeout?: number;
+export type PortOptions = GuestConnectionOptions & {
   /**
    * Set true to log copiously in the console.
    */
@@ -231,9 +228,10 @@ export class Port<GuestApi = unknown>
    * with the extension's bootstrap frame, so they can share context and events.
    */
   public attachUI<T = unknown>(
-    iframe: HTMLIFrameElement
+    iframe: HTMLIFrameElement,
+    connectOptions: GuestConnectionOptions = {}
   ): Promise<CrossRealmObject<T>> {
-    return this.attachFrame(iframe, {
+    return this.attachFrame(iframe, connectOptions, {
       onIframeResize: (dimensions: { height: number; width: number }) => {
         this.emit("guestresize", {
           dimensions,
@@ -337,7 +335,8 @@ export class Port<GuestApi = unknown>
 
   private attachFrame<T = unknown>(
     iframe: HTMLIFrameElement,
-    addedMethods: object = {}
+    connectOptions: PortOptions = {},
+    addedMethods: RemoteHostApis = {}
   ) {
     // at least this is necessary
     normalizeIframe(iframe);
@@ -348,6 +347,7 @@ export class Port<GuestApi = unknown>
         logger: this.logger,
         targetOrigin: this.url.origin,
         timeout: this.timeout,
+        ...connectOptions,
       },
       {
         getSharedContext: () => this.sharedContext,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Exposes `timeout` parameter for guest connections to users of `Extensible` and `GuestUIFrame`. The `GuestUIFrame` component now takes a `timeout` prop which can override the default timeout in Host (currently 10 seconds).

<!--- Describe your changes in detail -->

## Related Issue

SITES-11547

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

The 10 second default timeout for guest connections was an arbitrary choice, and it doesn't seem realistic for most UIX scenarios, which we should expect to be much lower latency. But it wasn't modifiable by implementors of specific extension points or GuestUIFrame containers. For a use case where a GuestUIFrame (for example) should be connected much faster in production, the SDK doesn't give implementors the ability to fail fast.


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
