### PR TITLE
chore: support ES2019-only build pipelines

### DIFF
--- a/configs/common-tsupconfig.js
+++ b/configs/common-tsupconfig.js
@@ -37,20 +37,20 @@ const base = {
   tsconfig: "./tsconfig.json", // see above
   format: ["cjs"],
   platform: "browser",
-  target: "ES2020", // TODO: this is cool, right?
   replaceNodeEnv: true,
   legacyOutput: true,
   treeshake: "recommended",
 };
 
-
 const configs = {
+  /** @type {import("tsup").Options} */
   development: {
     ...base,
     sourcemap: true,
     declarationMap: false,
     splitting: false,
   },
+  /** @type {import("tsup").Options} */
   production: {
     ...base,
     clean: true,

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -14,7 +14,7 @@
     "moduleResolution": "node",
     "noImplicitAny": true,
     "preserveWatchOutput": true,
-    "target": "ES2020",
+    "target": "ES2019",
     "sourceMap": true
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Transpile to ES2019 instead of ES2020.

Practically, this only means we start transpiling the optional chaining operator `foo?.bar`. Nothing else in the bundle appears to change.

<!--- Describe your changes in detail -->

## Related Issue

https://github.com/parcel-bundler/parcel/issues/4458

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

At least one user of the package is running a build system that [can't transpile that syntax.](https://github.com/parcel-bundler/parcel/issues/4458#issuecomment-611959716)

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Passed usual battery

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
