### PR TITLE
fix: properly load extensions that do not register methods

### DIFF
--- a/packages/uix-host/src/port.ts
+++ b/packages/uix-host/src/port.ts
@@ -250,24 +250,13 @@ export class Port<GuestApi = unknown>
    * declared in an array of keys, description the names of the functions and
    * methods that the Port will expose.
    */
-  public hasCapabilities(requiredMethods: CapabilitySpec<GuestApis>) {
+  public hasCapabilities(requiredCapabilities: CapabilitySpec<GuestApis>) {
     this.assertReady();
     return (
       this.apis &&
-      Object.keys(requiredMethods).every((key) => {
-        if (!Reflect.has(this.apis, key)) {
-          return false;
-        }
-        const api = this.apis[key];
-        const methodList = requiredMethods[
-          key as keyof typeof requiredMethods
-        ] as string[];
-        return methodList.every(
-          (methodName: string) =>
-            Reflect.has(api, methodName) &&
-            typeof api[methodName as keyof typeof api] === "function"
-        );
-      })
+      Object.entries(requiredCapabilities).every(([apiName, methodNames]) =>
+        this.hasCapability(apiName, methodNames as string[])
+      )
     );
   }
 
@@ -321,6 +310,17 @@ export class Port<GuestApi = unknown>
   // #endregion Public Methods (6)
 
   // #region Private Methods (6)
+
+  private hasCapability(apiName: string, methodNames: string[]) {
+    const api = this.apis[apiName];
+    return (
+      api &&
+      methodNames.every(
+        (methodName: keyof typeof api) =>
+          Reflect.has(api, methodName) && typeof api[methodName] === "function"
+      )
+    );
+  }
 
   private assert(
     condition: boolean,

--- a/packages/uix-host/src/port.ts
+++ b/packages/uix-host/src/port.ts
@@ -252,20 +252,23 @@ export class Port<GuestApi = unknown>
    */
   public hasCapabilities(requiredMethods: CapabilitySpec<GuestApis>) {
     this.assertReady();
-    return Object.keys(requiredMethods).every((key) => {
-      if (!Reflect.has(this.apis, key)) {
-        return false;
-      }
-      const api = this.apis[key];
-      const methodList = requiredMethods[
-        key as keyof typeof requiredMethods
-      ] as string[];
-      return methodList.every(
-        (methodName: string) =>
-          Reflect.has(api, methodName) &&
-          typeof api[methodName as keyof typeof api] === "function"
-      );
-    });
+    return (
+      this.apis &&
+      Object.keys(requiredMethods).every((key) => {
+        if (!Reflect.has(this.apis, key)) {
+          return false;
+        }
+        const api = this.apis[key];
+        const methodList = requiredMethods[
+          key as keyof typeof requiredMethods
+        ] as string[];
+        return methodList.every(
+          (methodName: string) =>
+            Reflect.has(api, methodName) &&
+            typeof api[methodName as keyof typeof api] === "function"
+        );
+      })
+    );
   }
 
   /**
@@ -281,10 +284,9 @@ export class Port<GuestApi = unknown>
    */
   public async load() {
     try {
-      if (!this.apis) {
+      if (!this.isLoaded) {
         await this.connect();
       }
-      return this.apis;
     } catch (e) {
       this.guestServer = null;
       this.error = e instanceof Error ? e : new Error(String(e));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Handle loading an extension properly when the GuestServer does not register any methods.

When that happens, the `apis` property of the `Port` that loaded that GuestServer remains null.

- Made `Port#hasCapabilities` return false if `this.apis` is null. This should stop or reduce the error messages `Reflect.has() called on non-object`.
- Changed `Port#load` to use the `isLoaded` boolean to check if load is complete, not the `apis` property.

## Related Issue

(Potentially all of these. Still testing, but this fix is important regardless; I ran up against this issue making storybooks for commons-extensible.)

SITES-11547
SITES-12126
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

There are some potential cases when a GuestServer wants only to call methods on the host. This causes unexpected errors.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
