### PR TITLE
make guest attach and register promises reject properly

### DIFF
--- a/packages/uix-guest/src/guest.ts
+++ b/packages/uix-guest/src/guest.ts
@@ -245,7 +245,7 @@ export class Guest<
     } catch (e) {
       this.emit("error", { guest: this, error: e });
       this.logger.error("Connection failed!", e);
-      return;
+      throw e;
     }
     try {
       this.sharedContext = new SharedContext(
@@ -254,6 +254,7 @@ export class Guest<
     } catch (e) {
       this.emit("error", { guest: this, error: e });
       this.logger.error("getSharedContext failed!", e);
+      throw e;
     }
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Discovered that the guest was not rejecting when it failed to connect.

<!--- Describe your changes in detail -->

## Related Issue

SITES-12126

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

```js
await register({ id: 'test' }); // if registration fails...
console.log('this still runs!');
```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
