### PR TITLE
fix mislabeled version in prerelease

### DIFF
--- a/configs/common-tsupconfig.js
+++ b/configs/common-tsupconfig.js
@@ -32,7 +32,8 @@ const base = {
   entry: ["src/index.ts"], // will be relative to the directory that uses it
   define: {
     UIX_SDK_BUILDMODE: mode,
-    UIX_SDK_VERSION: `"${require("../package.json").version}"`,
+    UIX_SDK_VERSION:
+      process.env.UIX_SDK_VERSION || `"${require("../package.json").version}"`,
   },
   tsconfig: "./tsconfig.json", // see above
   format: ["cjs"],

--- a/packages/uix-core/src/tunnel/tunnel-messenger.ts
+++ b/packages/uix-core/src/tunnel/tunnel-messenger.ts
@@ -8,6 +8,20 @@ type HandshakeAccepted = WrappedMessage<HandshakeAcceptedTicket>;
 type HandshakeOffered = WrappedMessage<HandshakeOfferedTicket>;
 type HandshakeMessage = HandshakeAccepted | HandshakeOffered;
 
+type ParsedVersion = {
+  major: string;
+  minor: string;
+  patch: string;
+  prerelease: string;
+};
+
+function getVersionParts(version: string): ParsedVersion {
+  const [major, minor, suffix] = version.split(".");
+  const [patch, prerelease = ""] = suffix.split("-");
+  return { major, minor, patch, prerelease };
+}
+const thisVersion = getVersionParts(VERSION);
+
 export class TunnelMessenger {
   private myOrigin: string;
   private remoteOrigin: string;
@@ -54,6 +68,16 @@ export class TunnelMessenger {
       typeof unwrap(message as HandshakeOffered).offers === "string"
     );
   }
+  isCompatibleVersion(versionString: string) {
+    const version = getVersionParts(versionString);
+    return (
+      version.major === thisVersion.major &&
+      version.minor === thisVersion.minor &&
+      version.prerelease === thisVersion.prerelease
+    );
+  }
+  isSamePrerelease(version: ParsedVersion) {}
+  isSameMinorVersion(version: ParsedVersion) {}
   isHandshake(message: unknown): message is HandshakeMessage {
     if (!isWrapped(message)) {
       this.logMalformed(message);
@@ -71,7 +95,10 @@ export class TunnelMessenger {
       return false;
     }
     const { version } = tunnelData;
-    if (version !== VERSION && !this.versionWarnings.has(version)) {
+    if (
+      !this.isCompatibleVersion(version) &&
+      !this.versionWarnings.has(version)
+    ) {
       this.versionWarnings.add(version);
       this.logger.warn(
         `SDK version mismatch. ${this.myOrigin} is using v${VERSION}, but received message from ${this.remoteOrigin} using SDK v${version}. Extensions may be broken or unresponsive.`


### PR DESCRIPTION
## Description

The release script that hardcodes the version string into the `uix-core` build artifact was broken. In the publish phase, it was building the bundles _before changing the version string on disk_, so the bundler was reading the old version string from package.json.

Because of this, the hardcoded "version" string in `0.8.0` is `0.7.0`! And the "version" string in `0.8.1` is `0.8.0`.

This fixes the version script so that:
- it stops logging warnings if both sides have the same minor and major version, but different patch versions or prerelease strings
- it reorders `release.mjs` code to modify the version string in package.json on disk before running the build which reads it
- it adds an env var override to the build script, so it doesn't rely on the order of execution in `release.mjs` either

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

This causes misleading errors in the console referring to a version mismatch if one side is running v0.8.0 and the other is running v0.8.1. The errors report the wrong versions, claiming that the side running v0.8.0 is actually running v0.7.0! This leads to a lot of wasted time in diagnosis and debugging.


<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
