### PR TITLE
chore: compat workaround for inaccurate versions in v0.8.0 and v0.8.1

### DIFF
--- a/packages/uix-core/src/tunnel/tunnel-messenger.ts
+++ b/packages/uix-core/src/tunnel/tunnel-messenger.ts
@@ -15,13 +15,24 @@ type ParsedVersion = {
   prerelease: string;
 };
 
+/**
+ * Due to a bug in release for 0.8.0 and 0.8.11, those versions have the
+ * wrong (previous) version number embedded.
+ */
+const VERSION_CORRECTED = {
+  "0.7.0": "0.8.0",
+  "0.8.0": "0.8.1",
+};
+
 function getVersionParts(version: string): ParsedVersion {
-  const [major, minor, suffix] = version.split(".");
+  const realVersion = VERSION_CORRECTED.hasOwnProperty(version)
+    ? VERSION_CORRECTED[version as keyof typeof VERSION_CORRECTED]
+    : version;
+  const [major, minor, suffix] = realVersion.split(".");
   const [patch, prerelease = ""] = suffix.split("-");
   return { major, minor, patch, prerelease };
 }
 const thisVersion = getVersionParts(VERSION);
-
 export class TunnelMessenger {
   private myOrigin: string;
   private remoteOrigin: string;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Due to the bug fixed in #34 there are two lingering versions which cause inaccurate version warnings. This patch corrects those version warnings.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
