### PR TITLE
Pass disableMetrics prop to host

### DIFF
--- a/packages/uix-host-react/src/components/Extensible.tsx
+++ b/packages/uix-host-react/src/components/Extensible.tsx
@@ -41,6 +41,18 @@ export interface ExtensibleProps extends Omit<HostConfig, "hostName"> {
    * {@inheritDoc HostConfig.sharedContext}
    */
   sharedContext?: SharedContextValues;
+  /**
+   * {@inheritDoc HostConfig.debug}
+   */
+  debug?: boolean;
+  /**
+   * {@inheritDoc HostConfig.disableMetrics}
+   */
+  disableMetrics?: boolean;
+  /**
+   * {@inheritDoc HostConfig.runtimeContainer}
+   */
+  runtimeContainer?: HTMLElement;
 }
 
 function areExtensionsDifferent(
@@ -78,6 +90,7 @@ export function Extensible({
   runtimeContainer,
   debug,
   sharedContext,
+  disableMetrics
 }: PropsWithChildren<ExtensibleProps>) {
   const hostName = appName || window.location.host || "mainframe";
 
@@ -108,7 +121,7 @@ export function Extensible({
       };
     }
 
-    const host = new Host({ debug, hostName, runtimeContainer, sharedContext });
+    const host = new Host({ debug, hostName, runtimeContainer, sharedContext, disableMetrics });
     setHost(host);
 
     if (!Object.entries(extensions).length) {

--- a/packages/uix-host-react/src/components/ExtensibleWrapper/ExtensibleWrapper.tsx
+++ b/packages/uix-host-react/src/components/ExtensibleWrapper/ExtensibleWrapper.tsx
@@ -42,6 +42,18 @@ export interface ExtensibleDefaultProps extends Omit<HostConfig, "hostName"> {
    * {@inheritDoc HostConfig.sharedContext}
    */
   sharedContext?: SharedContextValues;
+  /**
+   * {@inheritDoc HostConfig.debug}
+   */
+  debug?: boolean;
+  /**
+   * {@inheritDoc HostConfig.disableMetrics}
+   */
+  disableMetrics?: boolean;
+  /**
+   * {@inheritDoc HostConfig.runtimeContainer}
+   */
+  runtimeContainer?: HTMLElement;
   queryString?: string;
   service: string;
   extensionPoint: string;
@@ -63,6 +75,7 @@ export const ExtensibleWrapper = ({
   runtimeContainer,
   debug,
   sharedContext,
+  disableMetrics,
   experienceShellEnvironment,
   queryString,
   service,
@@ -124,6 +137,7 @@ export const ExtensibleWrapper = ({
       debug={debug}
       guestOptions={guestOptions}
       sharedContext={sharedContext}
+      disableMetrics={disableMetrics}
     >
       {children}
     </Extensible>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
disableMetrics prop is not used in host creation for Extensible and ExtensibleWrapper.

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
