### PR TITLE
SITES-41734: fix loading flag staying false while host is loading

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,86 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  lint-and-unit:
+    name: Lint and Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Unit tests
+        run: npm run test:unit
+
+  e2e-local:
+    name: E2E Local Dist Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build SDK packages
+        run: npm run build
+
+      - name: Install host app dependencies
+        working-directory: e2e/local-dist/host-app
+        run: npm install
+
+      - name: Install guest app dependencies
+        working-directory: e2e/local-dist/guest-app
+        run: npm install
+
+      - name: Install test dependencies
+        working-directory: e2e/local-dist/tests
+        run: npm install
+
+      - name: Copy local SDK dist into e2e apps
+        run: node scripts/copy-local-dist.js
+
+      - name: Start host app
+        working-directory: e2e/local-dist/host-app
+        run: PORT=3000 npm start &
+
+      - name: Start guest app
+        working-directory: e2e/local-dist/guest-app
+        run: PORT=3002 npm start &
+
+      - name: Wait for apps to be ready
+        run: npx wait-on http://localhost:3000 http://localhost:3002 --timeout 120000
+
+      - name: Run E2E tests
+        working-directory: e2e/local-dist/tests
+        run: npm test
+        env:
+          CI: true
+
+      - name: Upload screenshots on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-screenshots
+          path: e2e/local-dist/tests/artifacts/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,10 @@ on:
     branches: [main]
     paths:
       - 'packages/**'
-      - 'e2e/local-dist/**'
   push:
     branches: [main]
     paths:
       - 'packages/**'
-      - 'e2e/local-dist/**'
 
 jobs:
   unit:
@@ -33,60 +31,3 @@ jobs:
 
       - name: Unit tests
         run: npm run test:unit
-
-  e2e-local:
-    name: E2E Local Dist Tests
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20.19.5'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build SDK packages
-        run: npm run build
-
-      - name: Install host app dependencies
-        working-directory: e2e/local-dist/host-app
-        run: npm install
-
-      - name: Install guest app dependencies
-        working-directory: e2e/local-dist/guest-app
-        run: npm install
-
-      - name: Install test dependencies
-        working-directory: e2e/local-dist/tests
-        run: npm install
-
-      - name: Copy local SDK dist into e2e apps
-        run: node scripts/copy-local-dist.js
-
-      - name: Start host app
-        working-directory: e2e/local-dist/host-app
-        run: PORT=3000 npm start &
-
-      - name: Start guest app
-        working-directory: e2e/local-dist/guest-app
-        run: PORT=3002 npm start &
-
-      - name: Wait for apps to be ready
-        run: npx wait-on http://localhost:3000 http://localhost:3002 --timeout 120000
-
-      - name: Run E2E tests
-        working-directory: e2e/local-dist/tests
-        run: npm test
-        env:
-          CI: true
-
-      - name: Upload screenshots on failure
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: e2e-screenshots
-          path: e2e/local-dist/tests/artifacts/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,18 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    paths:
+      - 'packages/**'
+      - 'e2e/local-dist/**'
   push:
     branches: [main]
+    paths:
+      - 'packages/**'
+      - 'e2e/local-dist/**'
 
 jobs:
-  lint-and-unit:
-    name: Lint and Unit Tests
+  unit:
+    name: Unit Tests
     runs-on: ubuntu-latest
 
     steps:
@@ -16,14 +22,11 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '20.19.5'
           cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Lint
-        run: npm run lint
 
       - name: Unit tests
         run: npm run test:unit
@@ -37,7 +40,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '20.19.5'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Build SDK packages
+        run: npm run build
+
       - name: Unit tests
         run: npm run test:unit
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -2,9 +2,12 @@ import type { JestConfigWithTsJest } from "ts-jest";
 
 const sdkProject = (sdkName: string, overrides: JestConfigWithTsJest) => ({
   displayName: `uix-${sdkName}`,
-  testMatch: [`<rootDir>/packages/uix-${sdkName}/src/**/*.test.ts`],
+  testMatch: [`<rootDir>/packages/uix-${sdkName}/src/**/*.test.ts?(x)`],
   modulePathIgnorePatterns: ["<rootDir>/dist"],
   testEnvironment: "jsdom",
+  moduleNameMapper: {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+  },
   transform: {
     "^.+\\.tsx?$": [
       "ts-jest",

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -24,7 +24,7 @@ const sdkProject = (sdkName: string, overrides: JestConfigWithTsJest) => ({
 });
 
 const jestConfig = {
-  extensionsToTreatAsEsm: [".ts"],
+  extensionsToTreatAsEsm: [".ts", ".tsx"],
   moduleNameMapper: {
     "^(\\.{1,2}/.*)\\.js$": "$1",
   },

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,7 +3,7 @@ import type { JestConfigWithTsJest } from "ts-jest";
 const sdkProject = (sdkName: string, overrides: JestConfigWithTsJest) => ({
   displayName: `uix-${sdkName}`,
   testMatch: [`<rootDir>/packages/uix-${sdkName}/src/**/*.test.ts?(x)`],
-  modulePathIgnorePatterns: ["<rootDir>/dist"],
+  modulePathIgnorePatterns: ["<rootDir>/dist", "<rootDir>/e2e/"],
   testEnvironment: "jsdom",
   moduleNameMapper: {
     "^(\\.{1,2}/.*)\\.js$": "$1",

--- a/packages/uix-host-react/src/hooks/useExtensionListFetched.test.ts
+++ b/packages/uix-host-react/src/hooks/useExtensionListFetched.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import React from "react";
+import { renderHook } from "@testing-library/react-hooks";
+import { Host } from "@adobe/uix-host";
+import { ExtensionContext } from "../extension-context";
+import { useExtensionListFetched } from "./useExtensionListFetched";
+
+jest.mock("@adobe/uix-host");
+
+const mockHost = {} as unknown as Host;
+
+describe("useExtensionListFetched", () => {
+  test("returns false when extensionListFetched is false", () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(
+        ExtensionContext.Provider,
+        { value: { host: mockHost, extensionListFetched: false } },
+        children,
+      );
+
+    const { result } = renderHook(() => useExtensionListFetched(), { wrapper });
+    expect(result.current).toBe(false);
+  });
+
+  test("returns true when extensionListFetched is true", () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(
+        ExtensionContext.Provider,
+        { value: { host: mockHost, extensionListFetched: true } },
+        children,
+      );
+
+    const { result } = renderHook(() => useExtensionListFetched(), { wrapper });
+    expect(result.current).toBe(true);
+  });
+});

--- a/packages/uix-host-react/src/hooks/useExtensions.test.tsx
+++ b/packages/uix-host-react/src/hooks/useExtensions.test.tsx
@@ -203,7 +203,7 @@ describe("useExtension hook", () => {
     expect(result.current.extensions.length).toBe(2);
   });
 
-  test("loading resets to true on a subsequent load cycle when a guestload fires", async () => {
+  test("loading resets to true on a subsequent load cycle when guestbeforeload fires", async () => {
     // Start with host loading
     (mockHost as unknown as { loading: boolean }).loading = true;
     const { result } = renderHook(() =>
@@ -220,12 +220,11 @@ describe("useExtension hook", () => {
     });
     expect(result.current.loading).toBe(false);
 
-    // Simulate a second load cycle: host.loading flips to true and a guestload
-    // fires (host.loading is checked inside the guestload handler).
+    // Simulate a second load cycle via guestbeforeload (fires even when all
+    // guests fail to load, unlike guestload which requires at least one success).
     await act(async () => {
-      (mockHost as unknown as { loading: boolean }).loading = true;
-      for (const listener of mockListeners["guestload"] ?? []) {
-        listener(new Event("guestload"));
+      for (const listener of mockListeners["guestbeforeload"] ?? []) {
+        listener(new Event("guestbeforeload"));
       }
     });
     expect(result.current.loading).toBe(true);

--- a/packages/uix-host-react/src/hooks/useExtensions.test.tsx
+++ b/packages/uix-host-react/src/hooks/useExtensions.test.tsx
@@ -12,7 +12,7 @@
 
 import { GuestApis, VirtualApi } from "@adobe/uix-core";
 import { Host } from "@adobe/uix-host";
-import { renderHook } from "@testing-library/react-hooks";
+import { act, renderHook } from "@testing-library/react-hooks";
 import React, { ReactNode } from "react";
 import { ExtensibleComponentBoundary } from "../components/ExtensibleComponentBoundary";
 import { UseExtensionsConfig, useExtensions } from "./useExtensions";
@@ -72,24 +72,33 @@ const guests = [
     provide: jest.fn().mockName("guest.provide"),
   },
 ] as unknown as GuestApis[];
+const mockListeners: Record<string, EventListener[]> = {};
+
+const mockHost = {
+  addEventListener(event: string, handler: EventListener): () => void {
+    if (!mockListeners[event]) mockListeners[event] = [];
+    mockListeners[event].push(handler);
+    return function () {
+      mockListeners[event] = mockListeners[event].filter((h) => h !== handler);
+    };
+  },
+  destroy(): null {
+    return null;
+  },
+  getLoadedGuests() {
+    return guests;
+  },
+  loading: false,
+  removeEventListener(event: string, handler: EventListener): void {
+    if (mockListeners[event]) {
+      mockListeners[event] = mockListeners[event].filter((h) => h !== handler);
+    }
+  },
+} as unknown as Host;
+
 jest.mocked(useHost).mockReturnValue({
   error: undefined,
-  host: {
-    addEventListener(): () => void {
-      return function () {
-        //do nothing, since its a mock
-      };
-    },
-    removeEventListener(): void {
-      return null;
-    },
-    getLoadedGuests() {
-      return guests;
-    },
-    destroy(): null {
-      return null;
-    },
-  } as unknown as Host,
+  host: mockHost,
 });
 
 const configFactory = (): UseExtensionsConfig<GuestApis, VirtualApi> =>
@@ -127,6 +136,33 @@ describe("useExtension hook", () => {
     );
 
     expect(result.current.extensions.length).toBe(3);
+  });
+
+  test("loading is true while host.loading is true", () => {
+    (mockHost as unknown as { loading: boolean }).loading = true;
+    const { result } = renderHook(() =>
+      useExtensions<GuestApis, VirtualApi>(configFactory, []),
+    );
+    expect(result.current.loading).toBe(true);
+    (mockHost as unknown as { loading: boolean }).loading = false;
+  });
+
+  test("loading becomes false after loadallguests fires", async () => {
+    (mockHost as unknown as { loading: boolean }).loading = true;
+    const { result } = renderHook(() =>
+      useExtensions<GuestApis, VirtualApi>(configFactory, []),
+    );
+    expect(result.current.loading).toBe(true);
+
+    await act(async () => {
+      const listeners = mockListeners["loadallguests"] ?? [];
+      for (const listener of listeners) {
+        listener(new Event("loadallguests"));
+      }
+    });
+
+    expect(result.current.loading).toBe(false);
+    (mockHost as unknown as { loading: boolean }).loading = false;
   });
 
   test("returns filtered extensions when ExtensibleComponentBoundaryContext with extensionPoints value is provided with different version", () => {

--- a/packages/uix-host-react/src/hooks/useExtensions.test.tsx
+++ b/packages/uix-host-react/src/hooks/useExtensions.test.tsx
@@ -203,10 +203,10 @@ describe("useExtension hook", () => {
     expect(result.current.extensions.length).toBe(2);
   });
 
-  test("isLoading does not reset to true on a subsequent load cycle", async () => {
+  test("loading resets to true on a subsequent load cycle when a guestload fires", async () => {
     // Start with host loading
     (mockHost as unknown as { loading: boolean }).loading = true;
-    const { result, rerender } = renderHook(() =>
+    const { result } = renderHook(() =>
       useExtensions<GuestApis, VirtualApi>(configFactory, []),
     );
     expect(result.current.loading).toBe(true);
@@ -214,28 +214,29 @@ describe("useExtension hook", () => {
     // Complete the first load cycle
     await act(async () => {
       (mockHost as unknown as { loading: boolean }).loading = false;
-      const listeners = mockListeners["loadallguests"] ?? [];
-      for (const listener of listeners) {
+      for (const listener of mockListeners["loadallguests"] ?? []) {
         listener(new Event("loadallguests"));
       }
     });
     expect(result.current.loading).toBe(false);
 
-    // Simulate a second load cycle starting: host.loading becomes true again.
-    // The implementation only reads host.loading in useState initializer and
-    // in the useEffect that runs when baseDeps change. Since baseDeps (host
-    // reference) have not changed, the effect does not re-run, so isLoading
-    // stays false. This documents the current behavior -- isLoading will NOT
-    // return to true without a host reference change.
+    // Simulate a second load cycle: host.loading flips to true and a guestload
+    // fires (host.loading is checked inside the guestload handler).
     await act(async () => {
       (mockHost as unknown as { loading: boolean }).loading = true;
+      for (const listener of mockListeners["guestload"] ?? []) {
+        listener(new Event("guestload"));
+      }
     });
-    rerender();
+    expect(result.current.loading).toBe(true);
 
-    // Current behavior: loading remains false even though host.loading is true,
-    // because the loading useEffect does not re-run when host.loading changes.
-    // This is a potential bug -- consumers cannot rely on `loading` to reflect
-    // subsequent load cycles.
+    // Complete the second cycle
+    await act(async () => {
+      (mockHost as unknown as { loading: boolean }).loading = false;
+      for (const listener of mockListeners["loadallguests"] ?? []) {
+        listener(new Event("loadallguests"));
+      }
+    });
     expect(result.current.loading).toBe(false);
   });
 

--- a/packages/uix-host-react/src/hooks/useExtensions.test.tsx
+++ b/packages/uix-host-react/src/hooks/useExtensions.test.tsx
@@ -108,6 +108,23 @@ const configFactory = (): UseExtensionsConfig<GuestApis, VirtualApi> =>
   }) as UseExtensionsConfig<GuestApis, VirtualApi>;
 
 describe("useExtension hook", () => {
+  afterEach(() => {
+    // Reset mockHost.loading so a failing assertion in one test
+    // does not poison subsequent tests that depend on its value.
+    (mockHost as unknown as { loading: boolean }).loading = false;
+
+    // Drain all registered listeners so event handlers from one test
+    // do not leak into the next.
+    for (const event of Object.keys(mockListeners)) {
+      mockListeners[event] = [];
+    }
+
+    // Reset guest.provide() call history between tests.
+    for (const guest of guests) {
+      (guest as unknown as { provide: jest.Mock }).provide.mockClear();
+    }
+  });
+
   test("returns all extensions when no ExtensibleComponentBoundaryContext value is provided", () => {
     const { result } = renderHook(() =>
       useExtensions<GuestApis, VirtualApi>(configFactory, []),
@@ -144,7 +161,6 @@ describe("useExtension hook", () => {
       useExtensions<GuestApis, VirtualApi>(configFactory, []),
     );
     expect(result.current.loading).toBe(true);
-    (mockHost as unknown as { loading: boolean }).loading = false;
   });
 
   test("loading becomes false after loadallguests fires", async () => {
@@ -162,7 +178,6 @@ describe("useExtension hook", () => {
     });
 
     expect(result.current.loading).toBe(false);
-    (mockHost as unknown as { loading: boolean }).loading = false;
   });
 
   test("returns filtered extensions when ExtensibleComponentBoundaryContext with extensionPoints value is provided with different version", () => {
@@ -186,5 +201,103 @@ describe("useExtension hook", () => {
     );
 
     expect(result.current.extensions.length).toBe(2);
+  });
+
+  test("isLoading does not reset to true on a subsequent load cycle", async () => {
+    // Start with host loading
+    (mockHost as unknown as { loading: boolean }).loading = true;
+    const { result, rerender } = renderHook(() =>
+      useExtensions<GuestApis, VirtualApi>(configFactory, []),
+    );
+    expect(result.current.loading).toBe(true);
+
+    // Complete the first load cycle
+    await act(async () => {
+      (mockHost as unknown as { loading: boolean }).loading = false;
+      const listeners = mockListeners["loadallguests"] ?? [];
+      for (const listener of listeners) {
+        listener(new Event("loadallguests"));
+      }
+    });
+    expect(result.current.loading).toBe(false);
+
+    // Simulate a second load cycle starting: host.loading becomes true again.
+    // The implementation only reads host.loading in useState initializer and
+    // in the useEffect that runs when baseDeps change. Since baseDeps (host
+    // reference) have not changed, the effect does not re-run, so isLoading
+    // stays false. This documents the current behavior -- isLoading will NOT
+    // return to true without a host reference change.
+    await act(async () => {
+      (mockHost as unknown as { loading: boolean }).loading = true;
+    });
+    rerender();
+
+    // Current behavior: loading remains false even though host.loading is true,
+    // because the loading useEffect does not re-run when host.loading changes.
+    // This is a potential bug -- consumers cannot rely on `loading` to reflect
+    // subsequent load cycles.
+    expect(result.current.loading).toBe(false);
+  });
+
+  test("guest.provide() is called for each extension when extensions load", async () => {
+    const providedApi = { myMethod: jest.fn() };
+    const configWithProvides = (): UseExtensionsConfig<GuestApis, VirtualApi> =>
+      ({
+        requires: {},
+        provides: providedApi,
+      }) as unknown as UseExtensionsConfig<GuestApis, VirtualApi>;
+
+    renderHook(() =>
+      useExtensions<GuestApis, VirtualApi>(configWithProvides, []),
+    );
+
+    // The provides effect runs after render. Each loaded guest should
+    // receive the provided API via guest.provide().
+    for (const guest of guests) {
+      expect(
+        (guest as unknown as { provide: jest.Mock }).provide,
+      ).toHaveBeenCalledWith(providedApi);
+    }
+  });
+
+  test("guest.provide() is re-called when extensions list changes", async () => {
+    const providedApi = { myMethod: jest.fn() };
+    const configWithProvides = (): UseExtensionsConfig<GuestApis, VirtualApi> =>
+      ({
+        requires: {},
+        provides: providedApi,
+      }) as unknown as UseExtensionsConfig<GuestApis, VirtualApi>;
+
+    const { result } = renderHook(() =>
+      useExtensions<GuestApis, VirtualApi>(configWithProvides, []),
+    );
+
+    // Clear call counts after initial render
+    for (const guest of guests) {
+      (guest as unknown as { provide: jest.Mock }).provide.mockClear();
+    }
+
+    // Simulate a guest loading by firing guestload (the default "each" mode
+    // subscriber). This calls setExtensions(getExtensions()), which returns
+    // a new array reference and triggers the provides effect to re-run.
+    await act(async () => {
+      const listeners = mockListeners["guestload"] ?? [];
+      for (const listener of listeners) {
+        listener(new Event("guestload"));
+      }
+    });
+
+    // The provides effect depends on [provides, extensions]. When
+    // extensions changes (new array reference from getExtensions()),
+    // guest.provide() is called again for each extension. This documents
+    // that provide() is re-invoked on every load event, even if the
+    // provided API has not changed.
+    const extensionCount = result.current.extensions.length;
+    expect(extensionCount).toBeGreaterThan(0);
+    for (const guest of guests) {
+      expect(
+        (guest as unknown as { provide: jest.Mock }).provide,
+      ).toHaveBeenCalledWith(providedApi);
+    }
   });
 });

--- a/packages/uix-host-react/src/hooks/useExtensions.test.tsx
+++ b/packages/uix-host-react/src/hooks/useExtensions.test.tsx
@@ -261,6 +261,115 @@ describe("useExtension hook", () => {
     }
   });
 
+  test("loading is false on initial mount when host is not loading", () => {
+    (mockHost as unknown as { loading: boolean }).loading = false;
+    const { result } = renderHook(() =>
+      useExtensions<GuestApis, VirtualApi>(configFactory, []),
+    );
+    expect(result.current.loading).toBe(false);
+  });
+
+  test("returns loading:false and error when useHost returns an error", () => {
+    jest.mocked(useHost).mockReturnValueOnce({
+      host: undefined,
+      error: new Error("outside extension context"),
+    });
+    const { result } = renderHook(() =>
+      useExtensions<GuestApis, VirtualApi>(configFactory, []),
+    );
+    expect(result.current.loading).toBe(false);
+    expect(result.current.extensions).toHaveLength(0);
+    expect(result.current.error?.message).toBe("outside extension context");
+  });
+
+  test("extensions update on each guestload in updateOn:each mode (default)", async () => {
+    let callCount = 0;
+    const trackingHost = {
+      ...mockHost,
+      getLoadedGuests() {
+        callCount++;
+        return guests;
+      },
+    } as unknown as Host;
+    jest.mocked(useHost).mockReturnValueOnce({
+      error: undefined,
+      host: trackingHost,
+    });
+
+    renderHook(() => useExtensions<GuestApis, VirtualApi>(configFactory, []));
+    const initialCallCount = callCount;
+
+    await act(async () => {
+      for (const listener of mockListeners["guestload"] ?? []) {
+        listener(new Event("guestload"));
+      }
+    });
+
+    // getLoadedGuests should have been called again after guestload fired
+    expect(callCount).toBeGreaterThan(initialCallCount);
+  });
+
+  test("extensions do not update on guestload in updateOn:all mode", async () => {
+    let callCount = 0;
+    const trackingHost = {
+      ...mockHost,
+      getLoadedGuests() {
+        callCount++;
+        return guests;
+      },
+    } as unknown as Host;
+    jest.mocked(useHost).mockReturnValueOnce({
+      error: undefined,
+      host: trackingHost,
+    });
+
+    const allModeConfig = (): UseExtensionsConfig<GuestApis, VirtualApi> =>
+      ({ updateOn: "all" }) as UseExtensionsConfig<GuestApis, VirtualApi>;
+
+    renderHook(() => useExtensions<GuestApis, VirtualApi>(allModeConfig, []));
+    const initialCallCount = callCount;
+
+    await act(async () => {
+      for (const listener of mockListeners["guestload"] ?? []) {
+        listener(new Event("guestload"));
+      }
+    });
+
+    // guestload should not trigger getLoadedGuests in "all" mode
+    expect(callCount).toBe(initialCallCount);
+
+    await act(async () => {
+      for (const listener of mockListeners["loadallguests"] ?? []) {
+        listener(new Event("loadallguests"));
+      }
+    });
+
+    // loadallguests should trigger getLoadedGuests
+    expect(callCount).toBeGreaterThan(initialCallCount);
+  });
+
+  test("guestunload removes the unloaded guest from extensions", async () => {
+    const { result } = renderHook(() =>
+      useExtensions<GuestApis, VirtualApi>(configFactory, []),
+    );
+    expect(result.current.extensions.length).toBe(5);
+
+    await act(async () => {
+      for (const listener of mockListeners["guestunload"] ?? []) {
+        (listener as unknown as (e: CustomEvent) => void)(
+          new CustomEvent("guestunload", {
+            detail: { guest: guests[0] },
+          }),
+        );
+      }
+    });
+
+    expect(result.current.extensions.length).toBe(4);
+    expect(
+      result.current.extensions.find((e) => e.id === "extension-1"),
+    ).toBeUndefined();
+  });
+
   test("guest.provide() is re-called when extensions list changes", async () => {
     const providedApi = { myMethod: jest.fn() };
     const configWithProvides = (): UseExtensionsConfig<GuestApis, VirtualApi> =>

--- a/packages/uix-host-react/src/hooks/useExtensions.ts
+++ b/packages/uix-host-react/src/hooks/useExtensions.ts
@@ -116,15 +116,10 @@ export function useExtensions<
   deps: unknown[] = [],
 ): UseExtensionsResult<Incoming> {
   const { host, error } = useHost();
-  if (error) {
-    return {
-      extensions: NO_EXTENSIONS,
-      loading: false,
-      error,
-    };
-  }
-  const [hostError, setHostError] = useState<Error>();
   const extensionPoints = useContext(ExtensibleComponentBoundaryContext);
+  const [hostError, setHostError] = useState<Error>();
+  const [isLoading, setIsLoading] = useState(() => host?.loading ?? false);
+
   const boundryExtensionPointsAsString = extensionPoints?.map(
     ({
       service,
@@ -133,14 +128,19 @@ export function useExtensions<
     }: ExtensionRegistryEndpointRegistration) =>
       `${service}/${extensionPoint}/${version}`,
   );
-  const baseDeps = [host, ...deps];
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const {
     requires,
     provides,
     updateOn = "each",
-  } = useMemo(() => configFactory(host), baseDeps);
+  } = useMemo(
+    () => (host ? configFactory(host) : {}),
+    [host, ...deps], // eslint-disable-line react-hooks/exhaustive-deps
+  );
 
   const getExtensions = useCallback(() => {
+    if (!host) return NO_EXTENSIONS;
     const newExtensions = [];
     const guests = host.getLoadedGuests(requires);
 
@@ -162,61 +162,59 @@ export function useExtensions<
       }
     }
     return newExtensions.length === 0 ? NO_EXTENSIONS : newExtensions;
-  }, [...baseDeps, requires]);
-
-  const subscribe = useCallback(
-    (handler: EventListener) => {
-      const eventName = updateOn === "all" ? "loadallguests" : "guestload";
-      host.addEventListener(eventName, handler);
-
-      return () => {
-        host.removeEventListener(eventName, handler);
-      };
-    },
-    [...baseDeps, updateOn],
-  );
-
-  const subscribeToUnload = useCallback((handler: EventListener) => {
-    host.addEventListener("guestunload", handler);
-
-    return () => {
-      host.removeEventListener("guestunload", handler);
-    };
-  }, baseDeps);
-
-  const [isLoading, setIsLoading] = useState(() => host?.loading ?? false);
+  }, [host, requires]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const [extensions, setExtensions] = useState(() => getExtensions());
 
+  // Update extensions list when guests load or all guests have loaded
   useEffect(() => {
-    return subscribe(() => setExtensions(getExtensions()));
-  }, [subscribe]);
+    if (!host) return;
+    const eventName = updateOn === "all" ? "loadallguests" : "guestload";
+    return host.addEventListener(eventName, () =>
+      setExtensions(getExtensions()),
+    );
+  }, [host, updateOn, getExtensions]);
 
+  // Update extensions list when a guest unloads
+  useEffect(() => {
+    if (!host) return;
+    return host.addEventListener("guestunload", (e: CustomEvent) => {
+      const guest = e.detail?.guest as Port<GuestApis>;
+      if (guest?.id) {
+        setExtensions((prevExtensions) => {
+          const filtered = prevExtensions.filter(
+            (ext) => ext.id !== guest.id || ext.url !== guest.url,
+          );
+          return filtered.length === 0 ? NO_EXTENSIONS : filtered;
+        });
+      }
+    });
+  }, [host]);
+
+  // Track loading state. Subscribes to both guestload and loadallguests so that
+  // isLoading correctly resets to true at the start of a subsequent load cycle:
+  // guestload fires while host.loading is still true (before loadallguests), so
+  // checking host.loading there detects when a new load cycle begins.
+  // Known limitation: a reload with zero guests will not flip isLoading to true
+  // because guestload never fires and there is no "load started" event on Host.
   useEffect(() => {
     if (!host) return;
     setIsLoading(host.loading);
-    return host.addEventListener("loadallguests", () => setIsLoading(false));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, baseDeps);
+    const unsubGuestLoad = host.addEventListener("guestload", () => {
+      if (host.loading) setIsLoading(true);
+    });
+    const unsubLoadAll = host.addEventListener("loadallguests", () =>
+      setIsLoading(false),
+    );
+    return () => {
+      unsubGuestLoad();
+      unsubLoadAll();
+    };
+  }, [host]);
 
-  const unloadExtentionCallback = (e: CustomEvent) => {
-    const eventDetail = e.detail;
-    const guest = eventDetail.guest as Port<GuestApis>;
-
-    if (guest && guest.id) {
-      setExtensions((prevExtensions) => {
-        const filtered = prevExtensions.filter(
-          (ext) => ext.id !== guest.id || ext.url !== guest.url,
-        );
-        return filtered.length === 0 ? NO_EXTENSIONS : filtered;
-      });
-    }
-  };
-
-  useEffect(() => {
-    return subscribeToUnload(unloadExtentionCallback);
-  }, [subscribeToUnload]);
-
+  // Provide host APIs to loaded extensions.
+  // Note: Port has no unprovide() API so this effect cannot clean up after
+  // itself; guest.provide() is re-called whenever the extensions list changes.
   useEffect(() => {
     for (const guest of extensions) {
       if (provides) {
@@ -225,15 +223,21 @@ export function useExtensions<
     }
   }, [provides, extensions]);
 
-  useEffect(
-    () =>
-      host.addEventListener(
-        "error",
-        (event: Extract<HostEvents, { detail: { error: Error } }>) =>
-          setHostError(event.detail.error),
-      ),
-    baseDeps,
-  );
+  // Forward host errors to consumers
+  useEffect(() => {
+    if (!host) return;
+    return host.addEventListener(
+      "error",
+      (event: Extract<HostEvents, { detail: { error: Error } }>) =>
+        setHostError(event.detail.error),
+    );
+  }, [host]);
+
+  // Early return AFTER all hooks (Rules of Hooks compliance).
+  // host is undefined when error is defined (discriminated union from useHost).
+  if (error) {
+    return { extensions: NO_EXTENSIONS, loading: false, error };
+  }
 
   return {
     extensions,

--- a/packages/uix-host-react/src/hooks/useExtensions.ts
+++ b/packages/uix-host-react/src/hooks/useExtensions.ts
@@ -120,13 +120,17 @@ export function useExtensions<
   const [hostError, setHostError] = useState<Error>();
   const [isLoading, setIsLoading] = useState(() => host?.loading ?? false);
 
-  const boundryExtensionPointsAsString = extensionPoints?.map(
-    ({
-      service,
-      extensionPoint,
-      version,
-    }: ExtensionRegistryEndpointRegistration) =>
-      `${service}/${extensionPoint}/${version}`,
+  const boundryExtensionPointsAsString = useMemo(
+    () =>
+      extensionPoints?.map(
+        ({
+          service,
+          extensionPoint,
+          version,
+        }: ExtensionRegistryEndpointRegistration) =>
+          `${service}/${extensionPoint}/${version}`,
+      ),
+    [extensionPoints],
   );
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -162,7 +166,7 @@ export function useExtensions<
       }
     }
     return newExtensions.length === 0 ? NO_EXTENSIONS : newExtensions;
-  }, [host, requires]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [host, requires, boundryExtensionPointsAsString]);
 
   const [extensions, setExtensions] = useState(() => getExtensions());
 

--- a/packages/uix-host-react/src/hooks/useExtensions.ts
+++ b/packages/uix-host-react/src/hooks/useExtensions.ts
@@ -120,7 +120,7 @@ export function useExtensions<
   const [hostError, setHostError] = useState<Error>();
   const [isLoading, setIsLoading] = useState(() => host?.loading ?? false);
 
-  const boundryExtensionPointsAsString = useMemo(
+  const boundaryExtensionPointsAsString = useMemo(
     () =>
       extensionPoints?.map(
         ({
@@ -155,10 +155,10 @@ export function useExtensions<
         getAllExtensionPointsFromGuest(guest);
 
       if (
-        !boundryExtensionPointsAsString ||
+        !boundaryExtensionPointsAsString ||
         !allExtensionPoints.length ||
         isGuestExtensionPointInBoundary(
-          boundryExtensionPointsAsString,
+          boundaryExtensionPointsAsString,
           allExtensionPoints,
         )
       ) {
@@ -166,7 +166,7 @@ export function useExtensions<
       }
     }
     return newExtensions.length === 0 ? NO_EXTENSIONS : newExtensions;
-  }, [host, requires, boundryExtensionPointsAsString]);
+  }, [host, requires, boundaryExtensionPointsAsString]);
 
   const [extensions, setExtensions] = useState(() => getExtensions());
 
@@ -195,23 +195,20 @@ export function useExtensions<
     });
   }, [host]);
 
-  // Track loading state. Subscribes to both guestload and loadallguests so that
-  // isLoading correctly resets to true at the start of a subsequent load cycle:
-  // guestload fires while host.loading is still true (before loadallguests), so
-  // checking host.loading there detects when a new load cycle begins.
-  // Known limitation: a reload with zero guests will not flip isLoading to true
-  // because guestload never fires and there is no "load started" event on Host.
+  // Track loading state. Subscribes to guestbeforeload to detect the start of
+  // every load cycle (including cycles where all guests fail and guestload never
+  // fires), and to loadallguests to clear loading when the cycle completes.
   useEffect(() => {
     if (!host) return;
     setIsLoading(host.loading);
-    const unsubGuestLoad = host.addEventListener("guestload", () => {
-      if (host.loading) setIsLoading(true);
-    });
+    const unsubBeforeLoad = host.addEventListener("guestbeforeload", () =>
+      setIsLoading(true),
+    );
     const unsubLoadAll = host.addEventListener("loadallguests", () =>
       setIsLoading(false),
     );
     return () => {
-      unsubGuestLoad();
+      unsubBeforeLoad();
       unsubLoadAll();
     };
   }, [host]);
@@ -277,14 +274,14 @@ function getAllExtensionPointsFromGuest(guest: Port<GuestApis>): string[] {
 }
 
 function isGuestExtensionPointInBoundary(
-  boundryExtensionPointsAsString: string[],
+  boundaryExtensionPointsAsString: string[],
   guestExtensionPoints: string[],
 ) {
   return (
-    boundryExtensionPointsAsString?.length &&
+    boundaryExtensionPointsAsString?.length &&
     guestExtensionPoints?.length &&
     guestExtensionPoints.some((extensionPoint) =>
-      boundryExtensionPointsAsString.includes(extensionPoint),
+      boundaryExtensionPointsAsString.includes(extensionPoint),
     )
   );
 }

--- a/packages/uix-host-react/src/hooks/useExtensions.ts
+++ b/packages/uix-host-react/src/hooks/useExtensions.ts
@@ -184,11 +184,20 @@ export function useExtensions<
     };
   }, baseDeps);
 
+  const [isLoading, setIsLoading] = useState(() => host?.loading ?? false);
+
   const [extensions, setExtensions] = useState(() => getExtensions());
 
   useEffect(() => {
     return subscribe(() => setExtensions(getExtensions()));
   }, [subscribe]);
+
+  useEffect(() => {
+    if (!host) return;
+    setIsLoading(host.loading);
+    return host.addEventListener("loadallguests", () => setIsLoading(false));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, baseDeps);
 
   const unloadExtentionCallback = (e: CustomEvent) => {
     const eventDetail = e.detail;
@@ -228,7 +237,7 @@ export function useExtensions<
 
   return {
     extensions,
-    loading: extensions.length === 0 ? false : host.loading,
+    loading: isLoading,
     error: hostError,
   };
 }

--- a/packages/uix-host-react/src/hooks/useLoadingFlags.comparison.test.tsx
+++ b/packages/uix-host-react/src/hooks/useLoadingFlags.comparison.test.tsx
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2023 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Comparison tests: useExtensions().loading vs useExtensionListFetched()
+ *
+ * These tests document the behavioural difference between the two "are we done?"
+ * flags exposed to consumers:
+ *
+ * - extensionListFetched (from useExtensionListFetched):
+ *     Set once in Extensible's .finally() block after extensionsProvider()
+ *     resolves OR rejects. Meaning: "the registry has been queried; we know
+ *     what extensions should exist." One-way: true forever once set.
+ *
+ * - loading (from useExtensions):
+ *     Driven by host.loading + Host events (guestload, loadallguests).
+ *     Meaning: "extensions are actively connecting right now." Cyclic: goes
+ *     false → true → false on each load cycle.
+ *
+ * Tests 3 and 4 also document the SITES-41734 regression that was fixed.
+ * The old broken implementation computed loading as:
+ *   extensions.length === 0 ? false : host.loading
+ * which forced loading to false whenever the filtered extension list was empty,
+ * even while the host was actively loading.
+ */
+
+import { GuestApis, VirtualApi } from "@adobe/uix-core";
+import { Host } from "@adobe/uix-host";
+import { act, renderHook } from "@testing-library/react-hooks";
+import React, { ReactNode } from "react";
+import { ExtensionContext } from "../extension-context";
+import { UseExtensionsConfig, useExtensions } from "./useExtensions";
+import { useExtensionListFetched } from "./useExtensionListFetched";
+import { useHost } from "./useHost";
+
+jest.mock("@adobe/uix-host");
+jest.mock("./useHost");
+
+const mockListeners: Record<string, EventListener[]> = {};
+
+const mockHost = {
+  addEventListener(event: string, handler: EventListener): () => void {
+    if (!mockListeners[event]) mockListeners[event] = [];
+    mockListeners[event].push(handler);
+    return function () {
+      mockListeners[event] = mockListeners[event].filter((h) => h !== handler);
+    };
+  },
+  destroy(): null {
+    return null;
+  },
+  getLoadedGuests(): never[] {
+    return [];
+  },
+  loading: false,
+  removeEventListener(event: string, handler: EventListener): void {
+    if (mockListeners[event]) {
+      mockListeners[event] = mockListeners[event].filter((h) => h !== handler);
+    }
+  },
+} as unknown as Host;
+
+jest.mocked(useHost).mockReturnValue({
+  error: undefined,
+  host: mockHost,
+});
+
+const configFactory = (): UseExtensionsConfig<GuestApis, VirtualApi> =>
+  ({
+    requires: {},
+    provides: {},
+  }) as UseExtensionsConfig<GuestApis, VirtualApi>;
+
+function useBothFlags() {
+  const { loading } = useExtensions<GuestApis, VirtualApi>(configFactory, []);
+  const extensionListFetched = useExtensionListFetched();
+  return { loading, extensionListFetched };
+}
+
+function makeWrapper(extensionListFetched: boolean) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <ExtensionContext.Provider
+        value={{ host: mockHost, extensionListFetched }}
+      >
+        {children}
+      </ExtensionContext.Provider>
+    );
+  };
+}
+
+describe("useExtensions().loading vs useExtensionListFetched() comparison", () => {
+  afterEach(() => {
+    (mockHost as unknown as { loading: boolean }).loading = false;
+    for (const event of Object.keys(mockListeners)) {
+      mockListeners[event] = [];
+    }
+    jest.mocked(useHost).mockReturnValue({
+      error: undefined,
+      host: mockHost,
+    });
+  });
+
+  test("Test 1 — Before registry resolves: both flags are false", () => {
+    const { result } = renderHook(() => useBothFlags(), {
+      wrapper: makeWrapper(false),
+    });
+
+    expect(result.current.extensionListFetched).toBe(false);
+    expect(result.current.loading).toBe(false);
+  });
+
+  test("Test 2 — After registry resolves with empty list: extensionListFetched is true, loading stays false", () => {
+    // extensionsProvider() has completed (extensionListFetched = true), but the
+    // host was never loading — nothing to connect to. No load events are fired.
+    // Note: extensionListFetched = true alone does NOT mean extensions are
+    // ready to use; it only means the registry query finished.
+    const { result } = renderHook(() => useBothFlags(), {
+      wrapper: makeWrapper(true),
+    });
+
+    expect(result.current.extensionListFetched).toBe(true);
+    expect(result.current.loading).toBe(false);
+  });
+
+  test("Test 3 — Host loading but no extensions match the filter (SITES-41734 regression case)", () => {
+    // The registry has resolved (extensionListFetched = true) and the host is
+    // actively loading, but the filter returns no matching extensions.
+    //
+    // Old behaviour (pre-fix SITES-41734): loading would have been `false` here
+    // because `extensions.length === 0 ? false : host.loading` forced false
+    // whenever no extensions matched the filter — masking active loading.
+    //
+    // Fixed behaviour: loading reflects host.loading directly, so it is true.
+    const loadingHost = {
+      ...mockHost,
+      getLoadedGuests: jest.fn().mockReturnValue([]),
+      loading: true,
+    } as unknown as Host;
+    jest
+      .mocked(useHost)
+      .mockReturnValue({ error: undefined, host: loadingHost });
+
+    const { result } = renderHook(() => useBothFlags(), {
+      wrapper: makeWrapper(true),
+    });
+
+    expect(result.current.extensionListFetched).toBe(true);
+    expect(result.current.loading).toBe(true);
+  });
+
+  test("Test 4 — extensionListFetched stays true across a reload cycle; loading cycles true→false", async () => {
+    // extensionListFetched is a one-way flag: once true it never goes back.
+    // loading is cyclic: it goes false → true when a new load starts, then
+    // back to false when loadallguests fires.
+    //
+    // Old behaviour (pre-fix SITES-41734): if the extensions list happened to be
+    // empty at the moment guestload fired, loading would have stayed false even
+    // though the host was actively loading.
+    const { result } = renderHook(() => useBothFlags(), {
+      wrapper: makeWrapper(true),
+    });
+
+    // Initial state: registry resolved, host idle.
+    expect(result.current.extensionListFetched).toBe(true);
+    expect(result.current.loading).toBe(false);
+
+    // Simulate a new load cycle starting: host.loading flips to true and a
+    // guestload event fires (host.loading is checked inside that handler).
+    await act(async () => {
+      (mockHost as unknown as { loading: boolean }).loading = true;
+      for (const listener of mockListeners["guestload"] ?? []) {
+        listener(new Event("guestload"));
+      }
+    });
+
+    // extensionListFetched never reverts; loading reflects the new cycle.
+    expect(result.current.extensionListFetched).toBe(true);
+    expect(result.current.loading).toBe(true);
+
+    // Complete the reload cycle.
+    await act(async () => {
+      (mockHost as unknown as { loading: boolean }).loading = false;
+      for (const listener of mockListeners["loadallguests"] ?? []) {
+        listener(new Event("loadallguests"));
+      }
+    });
+
+    expect(result.current.extensionListFetched).toBe(true);
+    expect(result.current.loading).toBe(false);
+  });
+
+  test("Test 5 — Registry failure: extensionListFetched is true (from .finally()), loading stays false", () => {
+    // When extensionsProvider() throws, Extensible's .finally() block still
+    // sets extensionListFetched = true. The host never starts loading because
+    // no extensions were registered.
+    //
+    // extensionListFetched alone cannot distinguish registry success from
+    // failure; consumers that need to handle errors should pair it with the
+    // error state from the Extensible component.
+    const { result } = renderHook(() => useBothFlags(), {
+      wrapper: makeWrapper(true),
+    });
+
+    expect(result.current.extensionListFetched).toBe(true);
+    expect(result.current.loading).toBe(false);
+  });
+});

--- a/packages/uix-host-react/src/hooks/useLoadingFlags.comparison.test.tsx
+++ b/packages/uix-host-react/src/hooks/useLoadingFlags.comparison.test.tsx
@@ -174,12 +174,10 @@ describe("useExtensions().loading vs useExtensionListFetched() comparison", () =
     expect(result.current.extensionListFetched).toBe(true);
     expect(result.current.loading).toBe(false);
 
-    // Simulate a new load cycle starting: host.loading flips to true and a
-    // guestload event fires (host.loading is checked inside that handler).
+    // Simulate a new load cycle starting via guestbeforeload.
     await act(async () => {
-      (mockHost as unknown as { loading: boolean }).loading = true;
-      for (const listener of mockListeners["guestload"] ?? []) {
-        listener(new Event("guestload"));
+      for (const listener of mockListeners["guestbeforeload"] ?? []) {
+        listener(new Event("guestbeforeload"));
       }
     });
 


### PR DESCRIPTION
Two bugs caused loading to always return false:
1. Wrong ternary forced loading = false when no extensions matched the filter, even when host.loading was true.
2. In updateOn: each mode, no re-render fired after the last guest loaded because the hook only subscribed to guestload, not loadallguests.

Fix introduces a dedicated isLoading state initialised from host.loading and a new useEffect that subscribes to loadallguests (regardless of updateOn) to set isLoading = false when all guests have finished loading.

Also fixes jest.config.ts to pick up .test.tsx files and moves moduleNameMapper into each project config so .js extension stripping works correctly for TSX files.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
