### PR TITLE
[SITES-35203] fix(host-react): prevent GuestUIFrame crash when guest is undefined

### DIFF
--- a/e2e/host-app/src/App.js
+++ b/e2e/host-app/src/App.js
@@ -6,6 +6,7 @@ import HostAppRequires from './HostAppRequires';
 import HostAppDynamic from './HostAppDynamic';
 import HostAppCallbackAdd from './HostAppCallbackAdd';
 import HostAppRenderTest from './HostAppRenderTest';
+import HostAppUndefinedGuest from './HostAppUndefinedGuest';
 
 function getScenario() {
   const hash = window.location.hash;
@@ -15,6 +16,7 @@ function getScenario() {
   if (hash.startsWith('#/dynamic')) return 'dynamic';
   if (hash.startsWith('#/callback-add')) return 'callback-add';
   if (hash.startsWith('#/render-test')) return 'render-test';
+  if (hash.startsWith('#/undefined-guest')) return 'undefined-guest';
   return 'default';
 }
 
@@ -60,6 +62,10 @@ function App() {
 
   if (scenario === 'render-test') {
     return <HostAppRenderTest />;
+  }
+
+  if (scenario === 'undefined-guest') {
+    return <HostAppUndefinedGuest />;
   }
 
   const Component = components[scenario];

--- a/e2e/host-app/src/HostAppUndefinedGuest.jsx
+++ b/e2e/host-app/src/HostAppUndefinedGuest.jsx
@@ -1,0 +1,86 @@
+import React, { useState, useEffect } from 'react';
+import { Extensible, useExtensions, useHost, GuestUIFrame } from '@adobe/uix-host-react';
+
+const provider = async () => ({
+  extensionId: { id: 'extensionId', url: 'http://localhost:3002#/register' },
+});
+
+// Renders a visible marker if any descendant throws during render, instead of
+// letting the whole host tree unmount. Before the fix, GuestUIFrame threw
+// (`new URL(src, guest.url.href)` on an undefined guest) when its guest had
+// been removed, taking the host UI down with it.
+class FrameErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { crashed: false };
+  }
+  static getDerivedStateFromError() {
+    return { crashed: true };
+  }
+  render() {
+    if (this.state.crashed) {
+      return <div id="host-crashed">Guest frame crashed the host</div>;
+    }
+    return this.props.children;
+  }
+}
+
+function UndefinedGuestContent() {
+  const { extensions = [] } = useExtensions(() => ({
+    requires: { extensionNamespace: ['getMessage', 'setMessage'] },
+  }));
+  const { host } = useHost();
+  const [frame, setFrame] = useState(null);
+  const [removed, setRemoved] = useState(false);
+
+  // Capture the guest id/src once it has loaded, and keep them even after the
+  // guest is later removed — so the frame stays mounted with a now-stale id,
+  // exactly reproducing the host.modal.close() teardown from the ticket.
+  useEffect(() => {
+    const ext = extensions[0];
+    if (ext && !frame) {
+      setFrame({
+        id: ext.id,
+        src: ext.url.href ? ext.url.href.replace('register', '') : '',
+      });
+    }
+  }, [extensions, frame]);
+
+  const handleRemove = async () => {
+    if (host && frame) {
+      // Mirrors what host.modal.close() does internally: unload + drop the guest.
+      await host.removeGuest(frame.id, { url: '' });
+      setRemoved(true); // force a re-render of the still-mounted frame
+    }
+  };
+
+  return (
+    <div>
+      <div id="host-alive">host alive</div>
+      <p id="frame-guest-id">{frame ? frame.id : ''}</p>
+      <p id="frame-removed">{String(removed)}</p>
+      <button id="remove-guest-button" onClick={handleRemove}>
+        Remove guest
+      </button>
+      <div className="iframe-wrapper">
+        <FrameErrorBoundary>
+          {frame && (
+            <GuestUIFrame
+              id="iframe-for-guest"
+              guestId={frame.id}
+              src={frame.src}
+            />
+          )}
+        </FrameErrorBoundary>
+      </div>
+    </div>
+  );
+}
+
+export default function HostAppUndefinedGuest() {
+  return (
+    <Extensible debug={true} extensionsProvider={provider}>
+      <UndefinedGuestContent />
+    </Extensible>
+  );
+}

--- a/e2e/tests/tests/undefined-guest.js
+++ b/e2e/tests/tests/undefined-guest.js
@@ -1,0 +1,38 @@
+import { fixture, test, Selector } from 'testcafe';
+
+fixture('Undefined Guest GuestUIFrame')
+  .page('http://localhost:3000/#/undefined-guest');
+
+// Regression guard for SITES-35203: when a guest is removed while its
+// GuestUIFrame is still mounted (e.g. host.modal.close() tears the guest down),
+// the frame must render null instead of throwing and crashing the host subtree.
+test('GuestUIFrame renders null instead of crashing the host when its guest is removed', async (t) => {
+  const guestId = Selector('#frame-guest-id');
+  const iframe = Selector('#iframe-for-guest');
+  const crashed = Selector('#host-crashed');
+  const alive = Selector('#host-alive');
+
+  // Guest loads and the UI frame mounts.
+  await t
+    .expect(guestId.innerText)
+    .eql('extensionId', 'guest should load', { timeout: 30000 });
+  await t
+    .expect(iframe.exists)
+    .ok('GuestUIFrame should mount for the loaded guest', { timeout: 30000 });
+
+  // Remove the guest while the frame is still mounted with its (now stale) id.
+  await t.click('#remove-guest-button');
+  await t.expect(Selector('#frame-removed').innerText).eql('true');
+
+  // The host must survive: no crash boundary, sentinel still present, and the
+  // frame degrades to null rather than throwing during render.
+  await t
+    .expect(crashed.exists)
+    .notOk('host subtree must not crash when the guest is undefined');
+  await t.expect(alive.exists).ok('host UI should stay mounted');
+  await t
+    .expect(iframe.exists)
+    .notOk('GuestUIFrame should render null for a removed guest', {
+      timeout: 10000,
+    });
+});

--- a/packages/uix-host-react/jest.config.ts
+++ b/packages/uix-host-react/jest.config.ts
@@ -22,7 +22,8 @@ module.exports = {
   },
   moduleNameMapper: {
     "\\.(s?css)$": "<rootDir>/../../node_modules/jest-css-modules",
-    "../extension-context.js": "<rootDir>/src/extension-context.ts"
+    "../extension-context.js": "<rootDir>/src/extension-context.ts",
+    "^(\\.{1,2}/.*)\\.js$": "$1"
   },
   coverageReporters: ["cobertura", "lcov", "text"],
 //   reporters: ["default", "jest-junit"],

--- a/packages/uix-host-react/src/components/GuestUIFrame.test.tsx
+++ b/packages/uix-host-react/src/components/GuestUIFrame.test.tsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Adobe. All rights reserved.
+Copyright 2026 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/packages/uix-host-react/src/components/GuestUIFrame.test.tsx
+++ b/packages/uix-host-react/src/components/GuestUIFrame.test.tsx
@@ -1,0 +1,183 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import React from "react";
+import { render, waitFor, cleanup } from "@testing-library/react";
+import { Host } from "@adobe/uix-host";
+import { GuestUIFrame } from "./GuestUIFrame";
+import { useHost } from "../hooks/useHost";
+
+jest.mock("@adobe/uix-host", () => ({
+  ...jest.requireActual("@adobe/uix-host"),
+  Host: jest.fn(),
+}));
+jest.mock("../hooks/useHost");
+
+const mockedUseHost = jest.mocked(useHost);
+
+interface MockGuest {
+  id: string;
+  url: URL;
+  provide: jest.Mock;
+  attachUI: jest.Mock;
+  addEventListener: jest.Mock;
+}
+
+const createGuest = (id = "guest-1"): MockGuest => ({
+  id,
+  url: new URL("https://example.com/guest/"),
+  provide: jest.fn().mockName("guest.provide"),
+  attachUI: jest
+    .fn()
+    .mockName("guest.attachUI")
+    .mockResolvedValue({
+      tunnel: { destroy: jest.fn() },
+    }),
+  addEventListener: jest
+    .fn()
+    .mockName("guest.addEventListener")
+    .mockReturnValue(jest.fn()),
+});
+
+const mockHostWithGuest = (guest?: MockGuest) =>
+  ({
+    guests: {
+      get: jest.fn().mockReturnValue(guest),
+    },
+  } as unknown as Host);
+
+describe("GuestUIFrame", () => {
+  afterEach(() => {
+    cleanup();
+    jest.clearAllMocks();
+  });
+
+  it("renders null when no host is available", () => {
+    mockedUseHost.mockReturnValue({ host: undefined, error: undefined });
+
+    const { container } = render(
+      <GuestUIFrame guestId="guest-1" src="index.html" />
+    );
+
+    expect(container.querySelector("iframe")).toBeNull();
+  });
+
+  it("renders null without crashing when the guest is not found", () => {
+    mockedUseHost.mockReturnValue({
+      host: mockHostWithGuest(undefined),
+      error: undefined,
+    });
+
+    expect(() =>
+      render(<GuestUIFrame guestId="missing-guest" src="index.html" />)
+    ).not.toThrow();
+
+    const { container } = render(
+      <GuestUIFrame guestId="missing-guest" src="index.html" />
+    );
+    expect(container.querySelector("iframe")).toBeNull();
+  });
+
+  it("renders an iframe with a resolved src and name when the guest exists", () => {
+    const guest = createGuest("guest-1");
+    mockedUseHost.mockReturnValue({
+      host: mockHostWithGuest(guest),
+      error: undefined,
+    });
+
+    const { container } = render(
+      <GuestUIFrame guestId="guest-1" src="page.html" />
+    );
+
+    const iframe = container.querySelector("iframe");
+    expect(iframe).not.toBeNull();
+    expect(iframe?.getAttribute("src")).toBe(
+      "https://example.com/guest/page.html"
+    );
+    expect(iframe?.getAttribute("name")).toBe("uix-guest-guest-1");
+  });
+
+  it("attaches the UI and invokes onConnect once connected", async () => {
+    const guest = createGuest("guest-1");
+    mockedUseHost.mockReturnValue({
+      host: mockHostWithGuest(guest),
+      error: undefined,
+    });
+    const onConnect = jest.fn();
+
+    render(
+      <GuestUIFrame guestId="guest-1" src="page.html" onConnect={onConnect} />
+    );
+
+    await waitFor(() => {
+      expect(guest.attachUI).toHaveBeenCalled();
+      expect(onConnect).toHaveBeenCalled();
+    });
+  });
+
+  it("provides host methods to the guest when methods are passed", async () => {
+    const guest = createGuest("guest-1");
+    mockedUseHost.mockReturnValue({
+      host: mockHostWithGuest(guest),
+      error: undefined,
+    });
+    const methods = { ns: { doThing: jest.fn() } };
+
+    render(
+      <GuestUIFrame guestId="guest-1" src="page.html" methods={methods} />
+    );
+
+    await waitFor(() => {
+      expect(guest.provide).toHaveBeenCalledWith(methods);
+    });
+  });
+
+  it("registers a guestresize listener when onResize is provided", () => {
+    const guest = createGuest("guest-1");
+    mockedUseHost.mockReturnValue({
+      host: mockHostWithGuest(guest),
+      error: undefined,
+    });
+    const onResize = jest.fn();
+
+    render(
+      <GuestUIFrame guestId="guest-1" src="page.html" onResize={onResize} />
+    );
+
+    expect(guest.addEventListener).toHaveBeenCalledWith(
+      "guestresize",
+      expect.any(Function)
+    );
+  });
+
+  it("calls onConnectionError when the connection fails", async () => {
+    const guest = createGuest("guest-1");
+    guest.attachUI.mockRejectedValue(new Error("boom"));
+    mockedUseHost.mockReturnValue({
+      host: mockHostWithGuest(guest),
+      error: undefined,
+    });
+    const onConnectionError = jest.fn();
+
+    render(
+      <GuestUIFrame
+        guestId="guest-1"
+        src="page.html"
+        onConnectionError={onConnectionError}
+      />
+    );
+
+    await waitFor(() => {
+      expect(onConnectionError).toHaveBeenCalledWith(expect.any(Error));
+    });
+  });
+});

--- a/packages/uix-host-react/src/components/GuestUIFrame.tsx
+++ b/packages/uix-host-react/src/components/GuestUIFrame.tsx
@@ -95,14 +95,11 @@ export const GuestUIFrame = ({
 }: GuestUIProps) => {
   const ref = useRef<HTMLIFrameElement>();
   const { host } = useHost();
-  if (!host) {
-    return null;
-  }
-  const guest = host.guests.get(guestId);
-  const frameUrl = new URL(src, guest.url.href);
+  const guest = host ? host.guests.get(guestId) : undefined;
+  const guestId_ = guest?.id;
 
   useEffect(() => {
-    if (ref.current) {
+    if (ref.current && guest) {
       let mounted = true;
       let connection: CrossRealmObject<VirtualApi>;
       const connectionFrame = ref.current;
@@ -142,10 +139,10 @@ export const GuestUIFrame = ({
         }
       };
     }
-  }, [guest.id]);
+  }, [guestId_]);
 
   useEffect(() => {
-    if (ref.current && onResize) {
+    if (ref.current && guest && onResize) {
       const currentFrame = ref.current;
       return guest.addEventListener(
         "guestresize",
@@ -156,7 +153,12 @@ export const GuestUIFrame = ({
         }
       );
     }
-  }, [ref.current, guest.id, onResize]);
+  }, [ref.current, guestId_, onResize]);
+
+  if (!host || !guest) {
+    return null;
+  }
+  const frameUrl = new URL(src, guest.url.href);
 
   return (
     <iframe


### PR DESCRIPTION
## Jira

[SITES-35203](https://jira.corp.adobe.com/browse/SITES-35203)

## Summary

- Guard against a missing host or guest before resolving the frame URL and attaching the UI, so an unavailable guest renders `null` instead of throwing.
- Hooks now run unconditionally to satisfy the rules of hooks.
- Add unit tests for `GuestUIFrame` and a jest `moduleNameMapper` to strip the `.js` extension from relative imports.

## Root cause

**Reproduction:** a local dummy guest extension whose error handler calls `guestConnection.host.modal.close()` from within a `catch` block (per the example in the ticket):

```tsx
const handleClick = React.useCallback(async () => {
  if (!guestConnection) {
    throw new Error("Required data missing");
  }
  setLoading(true);
  try {
    await new Promise((resolve, reject) =>
      setTimeout(() => reject(new Error("Crash!")), 0)
    );
  } catch (error) {
    console.error("Error:", error);
    guestConnection.host.modal.close();
  }
}, [guestConnection]);
```

**Symptom:** calling `host.modal.close()` tears down the modal and removes the guest. On the next host render, `GuestUIFrame` is evaluated while the guest no longer exists, and the host UI crashes instead of unmounting cleanly.

**Analysis:** the failure was not in the extension. In `GuestUIFrame`, `host.guests.get(guestId)` can return `undefined` (guest already removed after the modal closed). The component then ran unconditionally:

- `new URL(src, guest.url.href)` — throws when `guest` is `undefined`.
- `useEffect` dependencies and bodies keyed on `guest.id` — dereference `undefined`.

Because the early `return null` only covered a missing `host` (not a missing `guest`), an undefined guest threw during render and crashed the subtree instead of degrading gracefully.

**Fix:** resolve the guest defensively (`host ? host.guests.get(guestId) : undefined`), key the effects on an optional `guest?.id`, gate effect bodies on `guest` being present, and return `null` when either `host` or `guest` is missing — after the hooks run, to satisfy the rules of hooks.

## Test plan

- [x] `npm run test -w packages/uix-host-react` (39 passed, incl. 7 new `GuestUIFrame` tests)
- [ ] Verify an undefined/unavailable guest renders nothing instead of crashing the host UI.