### PR TITLE
fix(e2e): pin typescript to prevent eslint-plugin-jest from crashing dev server

### DIFF
--- a/e2e/guest-app/package.json.dist
+++ b/e2e/guest-app/package.json.dist
@@ -15,6 +15,9 @@
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },
+  "overrides": {
+    "typescript": "5.2.2"
+  },
   "scripts": {
     "start": "node ./scripts/start.js",
     "build": "react-scripts build",

--- a/e2e/host-app/package.json.dist
+++ b/e2e/host-app/package.json.dist
@@ -14,6 +14,9 @@
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },
+  "overrides": {
+    "typescript": "5.2.2"
+  },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",


### PR DESCRIPTION
## Summary
- The E2E CI run for #148 failed 7/13 tests, all with the same symptom: TestCafe couldn't click any button because a full-viewport `#webpack-dev-server-client-overlay` iframe (CRA's compile-error overlay) was on top of the page.
- Root cause: `react-scripts`' ESLint webpack plugin failed to compile with `Environment key "jest/globals" is unknown`. Tracing it down: `eslint-plugin-jest` transitively depends on `@typescript-eslint/type-utils@5.62.0`, which reads `ts.TypeFlags.Any` from the `typescript` package. Nothing in that dependency chain constrains the `typescript` version (it's an unconstrained/optional peer), so a fresh `npm install` in `e2e/host-app` and `e2e/guest-app` resolves whatever `typescript` is newest at install time — currently a `7.x` release with a changed compiler API — which throws when `eslint-plugin-jest`'s rules load, silently breaking the plugin and failing ESLint's environment resolution.
- This is non-deterministic by nature (depends on what's newest on the registry at `npm install` time, since these e2e apps have no committed lockfile), so it can pass locally with a reused `node_modules` and fail in CI (or on any later fresh install) without any source change.
- Fix: pin `typescript` to `5.2.2` (matching the version already used at the repo root) via npm `overrides` in `e2e/host-app/package.json.dist` and `e2e/guest-app/package.json.dist`.

## Test plan
- [x] Reproduced the crash directly: `require('eslint-plugin-jest')` threw `TypeError: Cannot read properties of undefined (reading 'Any')` on a truly fresh install (confirmed `typescript@7.0.2` was resolved).
- [x] Applied the `typescript` override, did a clean `rm -rf node_modules` + fresh install, confirmed `typescript@5.2.2` is resolved and `eslint-plugin-jest` loads without throwing.
- [x] `npx eslint --print-config` now exits 0 with no "unknown environment" error.
- [x] Full `npm run build && npm run test:e2e` passes 12/12 on the fresh install (this branch is off `main`, before the `undefined-guest` test in #148 was added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)