### PR TITLE
Fix GuestUIFrame losing connection when moved within a stable-keyed list (SITES-42495)

### DIFF
--- a/e2e/guest-app/src/App.js
+++ b/e2e/guest-app/src/App.js
@@ -3,6 +3,7 @@ import {HashRouter, Route, Routes} from "react-router-dom";
 import Extention from './Extention';
 import ExtentionPartial from './ExtentionPartial';
 import Counter from './MainApp';
+import UiFrameProbe from './UiFrameProbe';
 
 function App() {
 
@@ -12,6 +13,7 @@ function App() {
                 <Route index element={<Counter/>}/>
                 <Route path="register" element={<Extention/>}/>
                 <Route path="register-partial" element={<ExtentionPartial/>}/>
+                <Route path="ui-frame" element={<UiFrameProbe/>}/>
             </Routes>
         </HashRouter>
     );

--- a/e2e/guest-app/src/UiFrameProbe.jsx
+++ b/e2e/guest-app/src/UiFrameProbe.jsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { attach } from '@adobe/uix-guest';
+
+// Computed once when this module is evaluated. It only changes if the iframe's
+// browsing context is actually torn down and reloaded (a real navigation) - a
+// hash-only route change or a parent re-render does NOT re-run this line.
+// This is how the test detects whether moving this frame in the host's DOM
+// silently reloaded it, as opposed to React simply relocating the same node.
+const bootId = Math.random().toString(36).slice(2, 10);
+
+function log(message) {
+  // eslint-disable-next-line no-console
+  console.log(`[uix-e2e-reorder] ${bootId} ${message}`);
+}
+
+export default function UiFrameProbe() {
+  const [status, setStatus] = useState('connecting');
+  const [error, setError] = useState('');
+  const attempted = useRef(false);
+
+  useEffect(() => {
+    if (attempted.current) return;
+    attempted.current = true;
+
+    const hashSearch = window.location.hash.split('?')[1] || '';
+    const params = new URLSearchParams(hashSearch);
+    const extensionId = params.get('id') || 'extensionId';
+    const timeout = Number(params.get('timeout')) || 5000;
+
+    log(`booted, attaching as "${extensionId}" (timeout ${timeout}ms)`);
+
+    attach({ id: extensionId, timeout })
+      .then(() => {
+        log('attach resolved: connected');
+        setStatus('connected');
+      })
+      .catch((e) => {
+        const message = (e && e.message) || String(e);
+        log(`attach rejected: ${message}`);
+        setStatus('error');
+        setError(message);
+      });
+  }, []);
+
+  return (
+    <div>
+      <p>UI frame probe</p>
+      <p id="boot-id">{bootId}</p>
+      <p id="attach-status">{status}</p>
+      <p id="attach-error">{error}</p>
+    </div>
+  );
+}

--- a/e2e/host-app/src/App.js
+++ b/e2e/host-app/src/App.js
@@ -6,6 +6,7 @@ import HostAppRequires from './HostAppRequires';
 import HostAppDynamic from './HostAppDynamic';
 import HostAppCallbackAdd from './HostAppCallbackAdd';
 import HostAppRenderTest from './HostAppRenderTest';
+import HostAppReorder from './HostAppReorder';
 
 function getScenario() {
   const hash = window.location.hash;
@@ -15,6 +16,7 @@ function getScenario() {
   if (hash.startsWith('#/dynamic')) return 'dynamic';
   if (hash.startsWith('#/callback-add')) return 'callback-add';
   if (hash.startsWith('#/render-test')) return 'render-test';
+  if (hash.startsWith('#/reorder')) return 'reorder';
   return 'default';
 }
 
@@ -60,6 +62,10 @@ function App() {
 
   if (scenario === 'render-test') {
     return <HostAppRenderTest />;
+  }
+
+  if (scenario === 'reorder') {
+    return <HostAppReorder />;
   }
 
   const Component = components[scenario];

--- a/e2e/host-app/src/HostAppReorder.jsx
+++ b/e2e/host-app/src/HostAppReorder.jsx
@@ -1,0 +1,91 @@
+import { useState } from 'react';
+import { Extensible, GuestUIFrame, useExtensions } from '@adobe/uix-host-react';
+
+// Same extension registered once (control frame via #/register); every row
+// attaches its OWN UI frame (#/ui-frame) to that single registered guest -
+// this mirrors a multifield where every item is rendered by the same
+// extension, one live iframe per item, all sharing one Port/guest registration.
+const provider = async () => ({
+  extensionId: { id: 'extensionId', url: 'http://localhost:3002#/register?id=extensionId' },
+});
+
+const UI_FRAME_URL = 'http://localhost:3002#/ui-frame?id=extensionId&timeout=5000';
+
+const ROWS_INITIAL = [
+  { id: 'row-a', label: 'Row A' },
+  { id: 'row-b', label: 'Row B' },
+];
+
+function Row({ rowId, label }) {
+  return (
+    <div id={`row-${rowId}`} data-row-id={rowId} style={{ border: '1px solid #999', margin: 8, padding: 8 }}>
+      <p>{label}</p>
+      <GuestUIFrame id={`iframe-${rowId}`} guestId="extensionId" src={UI_FRAME_URL} />
+    </div>
+  );
+}
+
+function ReorderableList() {
+  const [rows, setRows] = useState(ROWS_INITIAL);
+  // Positive control: gives Row A a brand new identity/key, forcing React to
+  // unmount + remount it for real, so the test can confirm a genuine remount
+  // still reconnects cleanly (proving the harness itself works).
+  const [rowAInstance, setRowAInstance] = useState(0);
+
+  const swap = () => {
+    // Pure position swap, same object identities/keys - mirrors
+    // canvasValuesStore.ts's swapMultiValues (array.splice in / splice out,
+    // no re-keying).
+    setRows((prev) => [prev[1], prev[0]]);
+  };
+
+  const remountRowA = () => setRowAInstance((n) => n + 1);
+
+  return (
+    <div>
+      <button id="swap-rows-button" onClick={swap}>
+        Swap rows
+      </button>
+      <button id="remount-row-a-button" onClick={remountRowA}>
+        Force remount row A
+      </button>
+      <div id="rows-container">
+        {rows.map((row) => (
+          <Row
+            key={row.id === 'row-a' ? `row-a-${rowAInstance}` : row.id}
+            rowId={row.id}
+            label={row.label}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// Only render the rows (and therefore GuestUIFrame) once the extension is
+// actually loaded - matching production, where CustomField is only chosen
+// as a field's renderer after its extension is known. Mounting GuestUIFrame
+// before `useHost()` resolves is a separate, pre-existing bug in
+// GuestUIFrame itself (host starts null, then becomes truthy on the same
+// instance, which skips its useEffect calls on the first render and trips
+// React's "Rendered more hooks than during the previous render" - masked
+// in every other e2e scenario by their use of key={Math.random()}, which
+// forces a fresh instance every render). That's out of scope here.
+function ReadyGate() {
+  const { extensions = [], loading } = useExtensions(() => ({}));
+  if (loading || extensions.length === 0) {
+    return <p id="extensions-loading">Loading extension...</p>;
+  }
+  return <ReorderableList />;
+}
+
+export default function HostAppReorder() {
+  return (
+    <div>
+      <h2>Multifield Reorder Scenario</h2>
+      <Extensible debug={true} extensionsProvider={provider}>
+        <ReadyGate />
+      </Extensible>
+    </div>
+  );
+}

--- a/e2e/tests/tests/multifield-reorder.js
+++ b/e2e/tests/tests/multifield-reorder.js
@@ -1,0 +1,123 @@
+import { fixture, test, Selector } from "testcafe";
+
+// Reproduces SITES-42495: a host renders one GuestUIFrame per "row" (e.g. a
+// multifield item), keyed by stable per-row identity rather than array
+// position - the same pattern @aem-sites/headless-components' Multifield
+// uses (a birth-assigned `multiIdx` that a pure position-swap never
+// re-keys). A stable key means React relocates the existing iframe DOM node
+// on reorder instead of unmounting/remounting it.
+//
+// If the browser silently reloads a live cross-origin iframe when it's moved
+// in the DOM (a documented risk - see @adobe/uix-host's HostConfig.runtimeContainer
+// comment), GuestUIFrame's connect effect (deps: [guest.id], which never
+// changes here) never re-runs, so the host never re-attaches - the reloaded
+// guest's fresh attach() call then times out.
+//
+// This test asserts the CORRECT behavior - both rows should still be
+// connected after the swap - and currently FAILS because of the bug. It
+// should start passing once SITES-42495 is fixed; no changes to the test
+// should be needed at that point.
+
+const rowASelector = "#iframe-row-a";
+const rowBSelector = "#iframe-row-b";
+
+fixture("Multifield reorder - stable-keyed GuestUIFrame across a position swap")
+  .page("http://localhost:3000/#/reorder");
+
+async function waitConnected(t, iframeSelector, label) {
+  await t.switchToIframe(iframeSelector);
+  await t
+    .expect(Selector("#attach-status").innerText)
+    .eql("connected", `${label} should connect on initial load`, { timeout: 10000 });
+  await t.switchToMainWindow();
+}
+
+async function readProbe(t, iframeSelector) {
+  await t.switchToIframe(iframeSelector);
+  const bootId = await Selector("#boot-id").innerText;
+  const status = await Selector("#attach-status").innerText;
+  const error = await Selector("#attach-error").innerText;
+  await t.switchToMainWindow();
+  return { bootId, status, error };
+}
+
+test("swapping two stable-keyed rows should not break either iframe's connection (SITES-42495)", async (t) => {
+  await t.expect(Selector(rowASelector).exists).ok("Row A iframe should exist", { timeout: 15000 });
+  await t.expect(Selector(rowBSelector).exists).ok("Row B iframe should exist", { timeout: 15000 });
+
+  await waitConnected(t, rowASelector, "Row A");
+  await waitConnected(t, rowBSelector, "Row B");
+
+  const before = {
+    a: await readProbe(t, rowASelector),
+    b: await readProbe(t, rowBSelector),
+  };
+
+  await t.click("#swap-rows-button");
+
+  // Give a silently-reloaded guest time to either reconnect or hit its
+  // (short, test-configured) attach() timeout.
+  await t.wait(6000);
+
+  const after = {
+    a: await readProbe(t, rowASelector),
+    b: await readProbe(t, rowBSelector),
+  };
+
+  // eslint-disable-next-line no-console
+  console.log("[multifield-reorder] probe result:", JSON.stringify({ before, after }, null, 2));
+
+  // The DOM nodes themselves must survive the swap (identified by their
+  // stable ids, regardless of which now sits in which visual position).
+  await t.expect(Selector(rowASelector).exists).ok("Row A iframe element should still exist after swap");
+  await t.expect(Selector(rowBSelector).exists).ok("Row B iframe element should still exist after swap");
+
+  // Precondition check, expected to keep passing either way: at least one
+  // row's iframe silently reloaded (new bootId) purely from being moved in
+  // the DOM - proving React relocated the live node rather than
+  // remounting it, and that the browser discarded its browsing context
+  // anyway. This is just context for the real assertions below; a reload
+  // happening is not itself the bug.
+  const aReloaded = after.a.bootId !== before.a.bootId;
+  const bReloaded = after.b.bootId !== before.b.bootId;
+  await t
+    .expect(aReloaded || bReloaded)
+    .ok(
+      `Expected at least one row's iframe to silently reload after the swap (this is a browser quirk, not the bug under test). before=${JSON.stringify(before)} after=${JSON.stringify(after)}`
+    );
+
+  // The actual bug: a silent reload should not be fatal. The host/SDK
+  // should notice the guest reconnecting and re-establish the tunnel, so
+  // both rows should read "connected" here. Today they don't - whichever
+  // row got moved is left permanently unreachable instead.
+  await t
+    .expect(after.a.status)
+    .eql(
+      "connected",
+      `Row A should still be connected after the swap. bootId ${before.a.bootId} -> ${after.a.bootId}, error="${after.a.error}"`
+    );
+  await t
+    .expect(after.b.status)
+    .eql(
+      "connected",
+      `Row B should still be connected after the swap. bootId ${before.b.bootId} -> ${after.b.bootId}, error="${after.b.error}"`
+    );
+});
+
+test("a genuine remount (new key) reconnects cleanly - positive control", async (t) => {
+  await t.expect(Selector(rowASelector).exists).ok("Row A iframe should exist", { timeout: 15000 });
+  await waitConnected(t, rowASelector, "Row A");
+
+  const before = await readProbe(t, rowASelector);
+
+  await t.click("#remount-row-a-button");
+  await t.wait(1000);
+
+  await waitConnected(t, rowASelector, "Row A (after remount)");
+  const after = await readProbe(t, rowASelector);
+
+  await t
+    .expect(after.bootId)
+    .notEql(before.bootId, "A real remount should produce a fresh boot id");
+  await t.expect(after.status).eql("connected", "A real remount should reconnect cleanly");
+});

--- a/packages/uix-core/src/tunnel/tunnel.ts
+++ b/packages/uix-core/src/tunnel/tunnel.ts
@@ -157,9 +157,24 @@ export class Tunnel extends EventEmitter {
     let frameStatusCheck: number;
     let timeout: number;
 
+    /**
+     * Deliberately does not gate on `!tunnel.isConnected`: a host can
+     * legitimately receive a fresh handshake offer from this same iframe
+     * after it's already connected once, if the iframe's browsing context
+     * was silently reloaded (e.g. the DOM node was relocated by the host's
+     * own re-render, which some browsers treat as a reload even though the
+     * element was never removed from the document - see the reload note in
+     * HostConfig.runtimeContainer). `target.contentWindow` still identifies
+     * the current window inside that same iframe element, so accepting the
+     * offer and calling `tunnel.connect()` again re-establishes the tunnel
+     * with a fresh MessagePort, matching the "may reconnect if the iframe
+     * reloads" behavior already documented on this method. A still-alive,
+     * non-reloaded guest never re-sends an offer once its own tunnel is
+     * connected (see Tunnel.toParent's sendOffer), so this can't fire
+     * spuriously for a healthy connection.
+     */
     const offerListener = (event: MessageEvent) => {
       if (
-        !tunnel.isConnected &&
         isFromOrigin(event, target.contentWindow, config.targetOrigin) &&
         messenger.isHandshakeOffer(event.data)
       ) {


### PR DESCRIPTION
## Description

A host that renders `GuestUIFrame` for items in a reorderable list, keyed by
stable per-item identity (not array position), loses the connection to that
guest permanently when an item is reordered - even though React never
unmounts the component. This PR adds an e2e test that reproduces the failure
and a one-line fix in `Tunnel.toIframe`.

## Related Issue

Reported internally as SITES-42495 (Adobe internal Jira - AEM Content
Fragment Editor customer escalation): https://jira.corp.adobe.com/browse/SITES-42495

There isn't a public GitHub issue for this - it came in through an internal
customer support ticket for a UIX extension embedded in AEM's Content
Fragment Editor, not through this repo's issue tracker.

## Motivation and Context

A customer's UIX extension provided a custom field renderer for a multifield
(repeatable field) in the AEM Content Fragment Editor. Reordering an item in
the multifield made that item's extension iframe go permanently blank - the
guest's `attach()` call would time out with "Timed out waiting for initial
response from parent after 20000ms". The PATCH/save of the reorder itself
succeeded; this was purely a UI connection problem, and it was 100%
reproducible.

Root cause, traced end to end:

1. The host's multifield implementation keys each row by a stable per-item
   id (not array position), so a reorder doesn't change any row's key.
2. Because the key is stable, React's reconciliation *moves* the existing
   `GuestUIFrame` DOM subtree to its new position instead of
   unmounting/remounting it.
3. Moving a live cross-origin iframe within the DOM is a well-known browser
   quirk that can silently discard and reload its browsing context, even
   though React itself never unmounted anything.
4. `GuestUIFrame`'s connection-setting `useEffect` depends only on
   `[guest.id]`, which never changes for a reorder, so it never re-runs and
   the host never re-attaches to the (now reloaded) iframe.
5. `Tunnel.toIframe`'s handshake listener (`offerListener`) only accepted an
   offer while `!tunnel.isConnected`, so once connected once, it would
   permanently ignore any further handshake offer from that same iframe -
   including the reloaded guest's fresh one. Its only watchdog
   (`frameStatusCheck`) checks whether the iframe was removed from the DOM,
   which doesn't catch an in-place reload.
6. The reloaded guest's fresh `attach()` call then times out waiting for a
   response the host was never going to send.

This is a general property of `@adobe/uix-host-react`'s `GuestUIFrame` /
`@adobe/uix-core`'s `Tunnel`, not specific to any one host application - it
reproduces with a plain React state swap and no drag-and-drop library
involved at all.

## How Has This Been Tested?

Added `e2e/tests/tests/multifield-reorder.js` plus supporting fixtures
(`e2e/host-app/src/HostAppReorder.jsx`, `e2e/guest-app/src/UiFrameProbe.jsx`,
routing wire-up in both apps' `App.js`). The scenario mounts two rows
sharing one registered extension, each with its own `GuestUIFrame` keyed by
stable per-row identity, and a button that swaps their positions via a pure
identity-preserving array swap (mirroring how a typical multifield reorder
updates its underlying value array).

- Before the fix: the test fails - the swapped row's guest gets a fresh
  boot id (proving the iframe silently reloaded) and its `attach-status`
  reads `"error"` with `"Timed out waiting for initial response from parent
  after 5000ms"`.
- After the fix: same test, unmodified, passes - the row still gets a fresh
  boot id (the browser still reloads the iframe; that part is unavoidable),
  but its `attach-status` now recovers to `"connected"`.
- A second test in the same file uses a genuine remount (new React key) as
  a positive control, confirming the harness reconnects cleanly when React
  actually unmounts/remounts - isolating the failure to the
  same-key-but-moved case specifically.
- Full suite run locally via `npm run test:e2e`: 14/14 passing on this
  branch, no regressions to the 12 pre-existing e2e tests.

Along the way, reproducing this also surfaced a separate, pre-existing
Rules-of-Hooks violation in `GuestUIFrame` itself (it returns `null` before
its `useEffect` calls when `host` is still null, which crashes if the same
instance later re-renders with `host` populated). That's out of scope for
this PR - the new test scenario sidesteps it by gating on extension-load
completion, matching real-world timing where a custom field renderer is
only chosen once its extension is already known - but it's worth its own
follow-up issue.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation. (No - the fixed
      behavior now matches what `Tunnel.toIframe`'s own doc comment already
      promised: "The tunnel may reconnect if the iframe reloads.")
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

---
Investigated and authored with [Claude Code](https://claude.com/claude-code).
