### PR TITLE
Fix Tunnel.toIframe breaking on a duplicate same-key handshake offer (SITES-48958)

### DIFF
--- a/e2e/guest-app/src/App.js
+++ b/e2e/guest-app/src/App.js
@@ -4,6 +4,7 @@ import Extention from './Extention';
 import ExtentionPartial from './ExtentionPartial';
 import Counter from './MainApp';
 import UiFrameProbe from './UiFrameProbe';
+import DuplicateOfferProbe from './DuplicateOfferProbe';
 
 function App() {
 
@@ -14,6 +15,7 @@ function App() {
                 <Route path="register" element={<Extention/>}/>
                 <Route path="register-partial" element={<ExtentionPartial/>}/>
                 <Route path="ui-frame" element={<UiFrameProbe/>}/>
+                <Route path="ui-frame-ping" element={<DuplicateOfferProbe/>}/>
             </Routes>
         </HashRouter>
     );

--- a/e2e/guest-app/src/DuplicateOfferProbe.jsx
+++ b/e2e/guest-app/src/DuplicateOfferProbe.jsx
@@ -1,0 +1,103 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { attach } from '@adobe/uix-guest';
+
+// Only changes if this module is genuinely re-evaluated (a real reload),
+// not on a hash-only route change or parent re-render.
+const bootId = Math.random().toString(36).slice(2, 10);
+
+function log(message) {
+  // eslint-disable-next-line no-console
+  console.log(`[uix-e2e-duplicate-offer] ${bootId} ${message}`);
+}
+
+export default function DuplicateOfferProbe() {
+  const [status, setStatus] = useState('connecting');
+  const [error, setError] = useState('');
+  const [pingStatus, setPingStatus] = useState('pending');
+  const [pingError, setPingError] = useState('');
+  const attempted = useRef(false);
+
+  useEffect(() => {
+    if (attempted.current) return;
+    attempted.current = true;
+
+    const hashSearch = window.location.hash.split('?')[1] || '';
+    const params = new URLSearchParams(hashSearch);
+    const extensionId = params.get('id') || 'extensionId';
+    const timeout = Number(params.get('timeout')) || 5000;
+    const pingDelay = Number(params.get('pingDelay')) || 2000;
+    const inject = params.get('inject') !== '0';
+
+    // Simulate the guest's own 100ms retry loop (Tunnel.toParent's
+    // sendOffer) firing one more time just as the host's "accepted" reply
+    // was in flight - the race behind SITES-48958. This must run INSIDE
+    // the guest's own realm: postMessage's `event.source` on the receiving
+    // end is whichever window's code actually called `.postMessage()`, so
+    // replaying from the host side would appear to come from the host, not
+    // the guest, and the host's isFromOrigin check would (correctly, from
+    // its own perspective) ignore it - it wouldn't test anything. The
+    // handshake offer is the very first thing the SDK ever posts to
+    // window.parent (the "guest-ready" message only fires after connecting),
+    // so capturing the first call is enough - no need to inspect its shape.
+    if (inject && window.parent && window.parent !== window) {
+      const originalPostMessage = window.parent.postMessage.bind(window.parent);
+      let capturedArgs = null;
+      window.parent.postMessage = function (...args) {
+        if (!capturedArgs) {
+          capturedArgs = args;
+          log('captured first message to parent, scheduling replay in 800ms');
+          setTimeout(() => {
+            log('replaying captured message to parent');
+            originalPostMessage(...capturedArgs);
+          }, 800);
+        }
+        return originalPostMessage(...args);
+      };
+    }
+
+    log(`booted, attaching as "${extensionId}" (timeout ${timeout}ms, inject=${inject})`);
+
+    attach({ id: extensionId, timeout })
+      .then((guestConnection) => {
+        log('attach resolved: connected');
+        setStatus('connected');
+
+        // Give the replay time to land (or not), then make a real RPC
+        // call over the tunnel. If the race silently swapped in a dead
+        // port pair, this hangs until the SDK's own ~10s host-call
+        // timeout rejects it.
+        setTimeout(() => {
+          log('sending post-connect ping');
+          guestConnection.host.probe
+            .ping()
+            .then((result) => {
+              log(`ping resolved: ${result}`);
+              setPingStatus('ok');
+            })
+            .catch((e) => {
+              const message = (e && e.message) || String(e);
+              log(`ping failed: ${message}`);
+              setPingStatus('error');
+              setPingError(message);
+            });
+        }, pingDelay);
+      })
+      .catch((e) => {
+        const message = (e && e.message) || String(e);
+        log(`attach rejected: ${message}`);
+        setStatus('error');
+        setError(message);
+      });
+  }, []);
+
+  return (
+    <div>
+      <p>Duplicate offer probe</p>
+      <p id="boot-id">{bootId}</p>
+      <p id="attach-status">{status}</p>
+      <p id="attach-error">{error}</p>
+      <p id="ping-status">{pingStatus}</p>
+      <p id="ping-error">{pingError}</p>
+    </div>
+  );
+}

--- a/e2e/host-app/src/App.js
+++ b/e2e/host-app/src/App.js
@@ -8,6 +8,7 @@ import HostAppCallbackAdd from './HostAppCallbackAdd';
 import HostAppRenderTest from './HostAppRenderTest';
 import HostAppUndefinedGuest from './HostAppUndefinedGuest';
 import HostAppReorder from './HostAppReorder';
+import HostAppDuplicateOffer from './HostAppDuplicateOffer';
 
 function getScenario() {
   const hash = window.location.hash;
@@ -19,6 +20,7 @@ function getScenario() {
   if (hash.startsWith('#/render-test')) return 'render-test';
   if (hash.startsWith('#/undefined-guest')) return 'undefined-guest';
   if (hash.startsWith('#/reorder')) return 'reorder';
+  if (hash.startsWith('#/duplicate-offer')) return 'duplicate-offer';
   return 'default';
 }
 
@@ -72,6 +74,10 @@ function App() {
 
   if (scenario === 'reorder') {
     return <HostAppReorder />;
+  }
+
+  if (scenario === 'duplicate-offer') {
+    return <HostAppDuplicateOffer />;
   }
 
   const Component = components[scenario];

--- a/e2e/host-app/src/HostAppDuplicateOffer.jsx
+++ b/e2e/host-app/src/HostAppDuplicateOffer.jsx
@@ -1,0 +1,33 @@
+import { Extensible, GuestUIFrame } from '@adobe/uix-host-react';
+
+const provider = async () => ({
+  extensionId: { id: 'extensionId', url: 'http://localhost:3002#/register?id=extensionId' },
+});
+
+// The actual duplicate-offer injection happens inside the guest itself
+// (DuplicateOfferProbe.jsx) - postMessage's event.source on the receiving
+// end reflects whichever realm's code called .postMessage(), so faking a
+// message "from the guest" has to originate from inside the guest's own
+// window, not the host's. ?inject=0 in the host URL is threaded through to
+// the guest's own query string to run a control scenario with no injected
+// duplicate.
+function buildUiFrameUrl() {
+  const inject = window.location.hash.includes('inject=0') ? '0' : '1';
+  return `http://localhost:3002#/ui-frame-ping?id=extensionId&timeout=5000&pingDelay=2000&inject=${inject}`;
+}
+
+export default function HostAppDuplicateOffer() {
+  return (
+    <div>
+      <h2>Duplicate Offer Race Scenario</h2>
+      <Extensible debug={true} extensionsProvider={provider}>
+        <GuestUIFrame
+          id="iframe-under-test"
+          guestId="extensionId"
+          src={buildUiFrameUrl()}
+          privateMethods={{ probe: { ping: () => 'pong' } }}
+        />
+      </Extensible>
+    </div>
+  );
+}

--- a/e2e/tests/tests/duplicate-offer-race.js
+++ b/e2e/tests/tests/duplicate-offer-race.js
@@ -1,0 +1,77 @@
+import { fixture, test, Selector } from "testcafe";
+
+// Reproduces SITES-48958: a guest's Tunnel.toParent resends its handshake
+// offer (same key) every 100ms until its own tunnel reports connected. If
+// the host's "accepted" reply takes long enough to process that a second,
+// redundant offer arrives after the host already connected - plausible
+// when many GuestUIFrame instances of the same extension initialize
+// concurrently on one CF Editor page, all competing for main-thread time -
+// Tunnel.toIframe's offerListener (which stopped checking !tunnel.isConnected
+// as part of the SITES-42495 fix) reprocesses it: opens a second
+// MessageChannel and calls tunnel.connect() again, closing the port the
+// guest is still actually using and replacing it with one paired to a port
+// the guest already stopped listening for (its acceptListener unsubscribes
+// after the first accept). Both sides report isConnected, but neither can
+// reach the other - a silent, permanent hang with no error and no timeout
+// (the initial connection timeout was already cleared on the first
+// successful connect).
+//
+// This test manufactures that exact race deterministically instead of
+// relying on incidental timing: HostAppDuplicateOffer.jsx captures the
+// guest's real first handshake offer and replays the identical message
+// ~800ms after the real connection has already succeeded. The guest then
+// makes a real post-connect RPC call, which will hang (and eventually
+// reject after the SDK's own ~10s host-call timeout) if the race broke the
+// tunnel.
+//
+// This test asserts the CORRECT behavior (the connection survives a
+// same-key duplicate offer) and currently FAILS.
+
+const iframeSelector = "#iframe-under-test";
+
+async function waitConnected(t, label) {
+  await t.switchToIframe(iframeSelector);
+  await t
+    .expect(Selector("#attach-status").innerText)
+    .eql("connected", `${label} should connect on initial load`, { timeout: 10000 });
+}
+
+fixture("Duplicate handshake offer should not break an established connection")
+  .page("http://localhost:3000/#/duplicate-offer");
+
+test("a same-key duplicate offer after connecting must not break the tunnel (SITES-48958)", async (t) => {
+  await t.expect(Selector(iframeSelector).exists).ok("iframe should exist", { timeout: 15000 });
+  await waitConnected(t, "guest");
+
+  // Wait past the simulated duplicate-offer replay (800ms) and the guest's
+  // own delayed post-connect ping (2000ms), with margin for the ping's
+  // ~10s internal RPC timeout if the tunnel was broken.
+  await t
+    .expect(Selector("#ping-status").innerText)
+    .notEql("pending", "ping should have resolved one way or another", { timeout: 13000 });
+
+  const pingStatus = await Selector("#ping-status").innerText;
+  const pingError = await Selector("#ping-error").innerText;
+  await t.switchToMainWindow();
+
+  await t
+    .expect(pingStatus)
+    .eql(
+      "ok",
+      `Expected the post-connect ping to succeed over the still-live tunnel, got "${pingStatus}" (${pingError})`
+    );
+});
+
+fixture("Duplicate offer race - control run (no injected duplicate)")
+  .page("http://localhost:3000/#/duplicate-offer?inject=0");
+
+test("ping succeeds normally when no duplicate offer is injected", async (t) => {
+  await t.expect(Selector(iframeSelector).exists).ok("iframe should exist", { timeout: 15000 });
+  await waitConnected(t, "guest");
+
+  await t
+    .expect(Selector("#ping-status").innerText)
+    .eql("ok", "ping should succeed with no interference", { timeout: 13000 });
+
+  await t.switchToMainWindow();
+});

--- a/packages/uix-core/src/tunnel/tunnel.test.ts
+++ b/packages/uix-core/src/tunnel/tunnel.test.ts
@@ -5,17 +5,43 @@ import { TunnelMessenger } from "./tunnel-messenger";
 
 class FakeIframe {
   contentWindow: MessagePort;
+  /**
+   * The paired end of contentWindow's own channel - i.e. what a real
+   * guest window's `window.addEventListener("message", ...)` would
+   * receive. A MessagePort's postMessage() delivers to its *pair*, not to
+   * itself, so anything the host sends via `contentWindow.postMessage()`
+   * (e.g. the handshake "accepted" reply) shows up here, not on
+   * contentWindow - tests observing what the host sent "to the iframe"
+   * must listen on this port, not on contentWindow.
+   */
+  guestSidePort: MessagePort;
   isConnected: boolean;
   src: string;
-  private channel = new MessageChannel();
   nodeName = "IFRAME";
   constructor() {
-    this.contentWindow = new MessageChannel().port1;
+    const channel = new MessageChannel();
+    const port = channel.port1;
+    // Tunnel.toIframe calls contentWindow.postMessage(message, targetOrigin,
+    // transfer) - the Window signature. A real MessagePort only accepts
+    // postMessage(message, transfer) (2 args), so the transfer list would
+    // land in the wrong parameter position and throw. Adapt the call
+    // instead of changing what contentWindow is, so it still behaves like
+    // a MessagePort for addEventListener/etc.
+    const originalPostMessage = port.postMessage.bind(port);
+    port.postMessage = ((
+      message: unknown,
+      _targetOrigin?: unknown,
+      transfer?: Transferable[]
+    ) => {
+      originalPostMessage(message, transfer);
+    }) as typeof port.postMessage;
+    this.contentWindow = port;
+    this.guestSidePort = channel.port2;
+    this.guestSidePort.start();
   }
   destroy() {
-    this.channel.port1.close();
-    this.channel.port2.close();
-    this.channel = null;
+    this.contentWindow.close();
+    this.guestSidePort.close();
   }
 }
 
@@ -229,5 +255,75 @@ describe("static Tunnel.toIframe(iframe, options)", () => {
       expect(connectMessageHandler).toHaveBeenCalledTimes(1);
       await testEventExchange(localTunnel, remoteTunnel);
     });
+  });
+});
+
+describe("Tunnel.toIframe offerListener - duplicate offer handling (SITES-48958)", () => {
+  // Unlike the describe.skip block above, this doesn't rely on jsdom's
+  // window.postMessage() to preserve event.source across "windows" (it
+  // doesn't - see the linked jsdom issue). Instead it dispatches a
+  // manually-constructed MessageEvent, which jsdom's MessageEvent
+  // constructor supports correctly, bypassing the broken code path
+  // entirely.
+  const targetOrigin = "https://example.com:4002";
+  const messenger = new TunnelMessenger({
+    myOrigin: "https://example.com",
+    targetOrigin,
+    logger: fakeConsole,
+  });
+
+  let hostTunnel: Tunnel;
+  let loadedFrame: FakeIframe;
+
+  function dispatchOffer(key: string) {
+    fireEvent(
+      window,
+      new MessageEvent("message", {
+        data: messenger.makeOffered(key),
+        origin: targetOrigin,
+        source: loadedFrame.contentWindow,
+      })
+    );
+  }
+
+  beforeEach(() => {
+    loadedFrame = new FakeIframe();
+    loadedFrame.src = targetOrigin;
+    loadedFrame.isConnected = true;
+  });
+
+  afterEach(() => {
+    hostTunnel && hostTunnel.destroy();
+    loadedFrame && loadedFrame.destroy();
+  });
+
+  it("ignores a same-key repeat once connected, but accepts a genuinely new key", async () => {
+    const acceptListener = jest.fn();
+    loadedFrame.guestSidePort.addEventListener("message", acceptListener);
+
+    hostTunnel = Tunnel.toIframe(loadedFrame as unknown as HTMLIFrameElement, {
+      targetOrigin,
+      timeout: 9999,
+    });
+
+    dispatchOffer("attempt-1");
+    await wait(100);
+    expect(acceptListener).toHaveBeenCalledTimes(1);
+    expect(hostTunnel.isConnected).toBe(true);
+
+    // Simulate Tunnel.toParent's 100ms retry loop firing once more before
+    // the guest noticed its own tunnel had connected - the exact race
+    // behind SITES-48958. Must be ignored: reprocessing it would tear down
+    // the working connection and replace it with one paired to a port the
+    // guest already stopped listening for.
+    dispatchOffer("attempt-1");
+    await wait(100);
+    expect(acceptListener).toHaveBeenCalledTimes(1);
+
+    // A genuinely new attempt - a different Tunnel.toParent instance, e.g.
+    // after a real reload - must still be accepted (SITES-42495).
+    dispatchOffer("attempt-2");
+    await wait(100);
+    expect(acceptListener).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/uix-core/src/tunnel/tunnel.ts
+++ b/packages/uix-core/src/tunnel/tunnel.ts
@@ -168,17 +168,37 @@ export class Tunnel extends EventEmitter {
      * the current window inside that same iframe element, so accepting the
      * offer and calling `tunnel.connect()` again re-establishes the tunnel
      * with a fresh MessagePort, matching the "may reconnect if the iframe
-     * reloads" behavior already documented on this method. A still-alive,
-     * non-reloaded guest never re-sends an offer once its own tunnel is
-     * connected (see Tunnel.toParent's sendOffer), so this can't fire
-     * spuriously for a healthy connection.
+     * reloads" behavior already documented on this method.
+     *
+     * However, a still-connecting (not yet reloaded) guest CAN legitimately
+     * re-send its offer: Tunnel.toParent's sendOffer retries every 100ms
+     * until the guest's own tunnel reports connected, and that only happens
+     * after it receives and processes this host's "accepted" reply, which
+     * travels asynchronously. If that round trip takes longer than 100ms -
+     * plausible when many GuestUIFrame instances of the same extension are
+     * initializing concurrently and competing for main-thread time - a
+     * second, redundant offer carrying the *same* key arrives after this
+     * host has already connected. Reprocessing that one would tear down the
+     * MessagePort the guest is actually using and replace it with one
+     * paired to a port the guest already stopped listening for (its
+     * acceptListener unsubscribes after the first accept), leaving both
+     * sides believing they're connected while unable to reach each other -
+     * a silent, permanent hang with no error or timeout (SITES-48958). So
+     * only a genuinely new key - a different guest-side Tunnel instance,
+     * i.e. an actual reload - is treated as a fresh connection attempt; a
+     * repeat of the key already accepted is ignored as a retry echo.
      */
+    let acceptedOfferId: string | undefined;
     const offerListener = (event: MessageEvent) => {
       if (
         isFromOrigin(event, target.contentWindow, config.targetOrigin) &&
         messenger.isHandshakeOffer(event.data)
       ) {
         const { offers, version } = unwrap(event.data);
+        if (tunnel.isConnected && offers === acceptedOfferId) {
+          return;
+        }
+        acceptedOfferId = offers;
         const accepted = messenger.makeAccepted(offers);
         if (versionCallback) {
           versionCallback(version);

--- a/packages/uix-core/src/tunnel/tunnel.ts
+++ b/packages/uix-core/src/tunnel/tunnel.ts
@@ -194,12 +194,11 @@ export class Tunnel extends EventEmitter {
         isFromOrigin(event, target.contentWindow, config.targetOrigin) &&
         messenger.isHandshakeOffer(event.data)
       ) {
-        const { offers, version } = unwrap(event.data);
-        if (tunnel.isConnected && offers === acceptedOfferId) {
+        const { offers: offerKey, version } = unwrap(event.data);
+        if (tunnel.isConnected && offerKey === acceptedOfferId) {
           return;
         }
-        acceptedOfferId = offers;
-        const accepted = messenger.makeAccepted(offers);
+        const accepted = messenger.makeAccepted(offerKey);
         if (versionCallback) {
           versionCallback(version);
         }
@@ -208,12 +207,20 @@ export class Tunnel extends EventEmitter {
           channel.port1,
         ]);
         tunnel.connect(channel.port2);
+        // Set only once the connection is actually established, so this
+        // variable unambiguously represents the key of the active
+        // connection rather than merely the last offer seen.
+        acceptedOfferId = offerKey;
       }
     };
     const cleanup = () => {
       clearTimeout(timeout);
       clearInterval(frameStatusCheck);
       window.removeEventListener("message", offerListener);
+      // Not currently load-bearing (this listener is already gone by the
+      // time cleanup runs), but makes the variable's lifecycle explicit
+      // rather than implicitly outliving the connection it describes.
+      acceptedOfferId = undefined;
     };
     timeout = window.setTimeout(() => {
       tunnel.abort(


### PR DESCRIPTION
## Description

A regression introduced by the SITES-42495 fix (#150): `Tunnel.toIframe`
could silently break an already-established, healthy connection if the
guest's own handshake retry loop sent one more redundant offer before it
noticed its own tunnel had connected. This PR adds an e2e test that
reproduces the failure deterministically and a small fix that restores
protection against it without reintroducing SITES-42495.

## Related Issue

Reported internally as SITES-48958 (Adobe internal Jira - Content Fragment
Editor customer escalation, Casio): https://jira.corp.adobe.com/browse/SITES-48958

No public GitHub issue exists for this - it came in through an internal
customer support ticket, same as SITES-42495.

## Motivation and Context

`uix-sdk` `1.1.10` (containing both #148 and #150) shipped to CF Editor
PROD `v1.58.0` on July 30. That same day, a customer (Casio) started
reporting Content Fragment custom fields intermittently stuck on "Loading
custom field..." forever - some fields on a page would render, others
wouldn't, with no error surfaced anywhere.

Root cause: `Tunnel.toIframe`'s `offerListener`, fixed in #150 to stop
permanently ignoring every offer once connected (so a genuinely reloaded
guest could reconnect), had no way to distinguish that legitimate case from
a much more mundane one - a guest that hasn't reloaded at all, just hasn't
finished processing the host's "accepted" reply yet:

1. `Tunnel.toParent`'s `sendOffer` retries every 100ms, using the *same*
   key, until the guest's own tunnel reports connected - which only
   happens after it receives and processes the host's "accepted" message,
   an async round trip.
2. If that round trip takes longer than 100ms - plausible when several
   `GuestUIFrame` instances of the same extension are initializing
   concurrently on one CF Editor page, all competing for main-thread time -
   a second, redundant offer with the *same* key arrives after the host has
   already connected.
3. Post-#150, the host reprocesses it: opens a second `MessageChannel`,
   posts a new port to the guest, and calls `tunnel.connect()` again -
   closing the port pair the guest is actually using and replacing it with
   one paired to a port the guest already stopped listening for (its
   `acceptListener` unsubscribes right after the first accept).
4. Both sides now report `isConnected: true`, but neither can reach the
   other. Nothing throws and nothing times out (the one-shot connection
   timeout was already cleared on the first successful connect) - a silent,
   permanent hang. That matches the "stuck loading" screenshots in the
   ticket exactly, and being a timing race, it only bites *some* fields on
   *some* page loads, matching "intermittent."

## The fix

Track the `offers` key of the handshake the tunnel is currently connected
with (`acceptedOfferId`). A repeat of that *same* key while already
connected is now ignored as a retry echo. A *different* key - a genuinely
new `Tunnel.toParent` instance, i.e. an actual reload - is still treated as
a fresh connection attempt, preserving the SITES-42495 behavior.

## How Has This Been Tested?

Added `e2e/tests/tests/duplicate-offer-race.js` plus supporting fixtures
(`e2e/host-app/src/HostAppDuplicateOffer.jsx`,
`e2e/guest-app/src/DuplicateOfferProbe.jsx`, routing wire-up in both apps'
`App.js`). The scenario can't rely on incidental timing jitter to be
reliable in CI, so it forces the race deterministically: the guest
monkey-patches its own `window.parent.postMessage` to capture its real
first handshake offer and replay the identical message, from inside its
own realm (so `event.source` genuinely reflects the guest, not the host),
~800ms after the connection has already succeeded. The guest then makes a
real post-connect RPC call (`host.probe.ping()`) exposed via `GuestUIFrame`'s
`privateMethods`.

- Before the fix: the test fails - `"Calling host.probe.ping() timed out
  after 10000ms"` (the SDK's own RPC-call timeout), since the tunnel was
  silently swapped for a dead port pair.
- After the fix: same test, unmodified, passes.
- A second test with the duplicate injection disabled (`?inject=0`) is a
  positive control, confirming the harness itself is sound (ping succeeds
  immediately absent any interference).
- `multifield-reorder.js` (SITES-42495) still passes unmodified, confirming
  this doesn't regress the original reconnect-after-reload fix.
- Full suite run locally via `npm run test:e2e`: **17/17 passing**, no
  regressions to any of the 15 pre-existing e2e tests.
- `npm run test:unit`: 15 suites, 83 passed, 2 pre-existing skips (the
  documented JSDOM `postMessage`/`MessageEvent` limitation on
  `Tunnel.toIframe`'s own describe block) - no change from before this PR.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation. (No - this
      restores behavior consistent with `Tunnel.toIframe`'s existing doc
      comment; no public API changed.)
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

---
Investigated and authored with [Claude Code](https://claude.com/claude-code).
